### PR TITLE
Permit error step 4/contact details

### DIFF
--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -213,13 +213,6 @@
       "header": "Provide your personal details",
       "subheader": "Complete this section carefully as these details will help us to find your information."
     },
-    "four": {
-      "header": "Provide your contact details",
-      "subheader": "We need your contact details to reply to your enquiry about why you have not received a BRP.",
-      "address": {
-        "title": "Please provide your address so that we contact you by post"
-      }
-    },
     "five": {
       "header": "Check your details",
       "subheader": "Check through the information that you have provided to make sure it is correct. If it is incorrect you can change it here.",
@@ -256,6 +249,13 @@
     "about-error": {
       "header": "Tell us about the error on your BRP",
       "subheader": "You can select one or more options if needed."
+    },
+    "contact-details": {
+      "header": "Provide your contact details",
+      "subheader": "We need your contact details to reply to your enquiry about why you have not received a BRP.",
+      "address": {
+        "title": "Please provide your address so that we contact you by post"
+      }
     }
   }
 }

--- a/routes/steps/error.js
+++ b/routes/steps/error.js
@@ -33,6 +33,19 @@ module.exports = {
       'address-county',
       'address-postcode'
     ],
+    next: '/contact-details'
+  },
+  '/contact-details': {
+    fields: [
+      'email',
+      'no-email',
+      'address-street',
+      'address-town',
+      'address-county',
+      'address-postcode',
+      'phone'
+    ],
+    backLink: '/same-address',
     next: '/confirmation'
   },
   '/confirmation': {

--- a/views/pages/contact-details.html
+++ b/views/pages/contact-details.html
@@ -4,9 +4,10 @@
   {{> partials-navigation}}
 {{/propositionHeader}}
 
-{{$header}}{{#t}}steps.four.header{{/t}}{{/header}}
+{{$header}}{{#t}}pages.contact-details.header{{/t}}{{/header}}
 
 {{$content}}
+  <p>{{#t}}pages.contact-details.subheader{{/t}}</p>
   {{<partials-form}}
 
     {{$form}}
@@ -22,7 +23,7 @@
             </span>
         </legend>
 
-        <p>{{#t}}steps.four.address.title{{/t}}</p>
+        <p>{{#t}}pages.contact-details.address.title{{/t}}</p>
 
         {{#input-text}}address-street{{/input-text}}
 


### PR DESCRIPTION
- add contact-details as a step in /permit-error
- remove steps.four.* from translations file
- add pages.contact-details to translations file
- update template with correct translations
- add subheader to contact-details template

![](https://media3.giphy.com/media/BP9eSu9cnnGN2/200.gif)