### PR TITLE
Validation permit delivery

### DIFF
--- a/acceptance_tests/Gemfile.lock
+++ b/acceptance_tests/Gemfile.lock
@@ -1,0 +1,67 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    cliver (0.3.2)
+    cucumber (2.0.0)
+      builder (>= 2.1.2)
+      cucumber-core (~> 1.1.3)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.1.3)
+      gherkin (~> 2.12.0)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
+    multi_json (1.11.2)
+    multi_test (0.1.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
+    rack (1.6.4)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.1)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  capybara
+  cucumber
+  poltergeist
+  rspec
+
+BUNDLED WITH
+   1.10.5

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -4,6 +4,7 @@ $path: "../img/";
 
 @import "./alert.scss";
 @import "./icons.scss";
+@import "./validation.scss";
 
 
 .phase-banner {

--- a/assets/scss/validation.scss
+++ b/assets/scss/validation.scss
@@ -1,0 +1,7 @@
+.validation-error {
+  .form-date {
+    .form-group.validation-error {
+      border-left: none;
+    }
+  }
+}

--- a/controllers/letter-received.js
+++ b/controllers/letter-received.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var util = require('util');
+var Controller = require('hmpo-form-wizard').Controller;
+var ErrorClass = require('hmpo-form-wizard').Error;
+var i18n = require('i18n-future')();
+var debug = require('debug')('controllers:letter-received');
+
+var Received = function Received() {
+  ErrorClass.prototype.translate = i18n.translate.bind(i18n);
+  Controller.apply(this, arguments);
+};
+
+util.inherits(Received, Controller);
+
+function deleteDateErrors(err) {
+  delete err['delivery-date-day'];
+  delete err['delivery-date-month'];
+  delete err['delivery-date-year'];
+  delete err['delivery-date'];
+}
+
+function notReceived(form) {
+  return form && form.values.received !== 'yes';
+}
+
+function isDateError(err) {
+  return err['delivery-date-day'] || err['delivery-date-month'] || err['delivery-date-year'];
+}
+
+function errorType(err) {
+  var result = 'numeric';
+  Object.keys(err).forEach(function eachError(value) {
+    if (err[value].type === 'required') {
+      result = 'required';
+    }
+  });
+  return result;
+}
+
+Received.prototype.setErrors = function setErrors(err, req) {
+  debug('Setting errors with %o', err);
+
+  if (err && notReceived(req.form)) {
+    deleteDateErrors(err);
+  }
+
+  if (err && isDateError(err)) {
+    err['delivery-date'] = new ErrorClass('delivery-date', {
+      key: 'delivery-date',
+      type: errorType(err),
+      redirect: undefined
+    });
+  }
+
+  Controller.prototype.setErrors.apply(this, arguments);
+};
+
+Received.prototype.validateField = function validateField(key, req) {
+  debug('Validating field %s', key);
+
+  if (notReceived(req.form)) {
+    if (key.indexOf('delivery-date') !== -1) {
+      return undefined;
+    }
+  }
+  return Controller.prototype.validateField.apply(this, arguments);
+};
+
+module.exports = Received;

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -5,6 +5,18 @@
     "submit": "Submit",
     "change": "Change"
   },
+  "errorlist": {
+    "title": "Please fix the following error(s)"
+  },
+  "validation": {
+    "delivery-date": {
+      "required": "Date is a required field",
+      "numeric": "Date must be a number"
+    },
+    "received": {
+      "required": "Have you received a letter?"
+    }
+  },
   "fields": {
     "received": {
       "options": {
@@ -17,6 +29,7 @@
       }
     },
     "delivery-date": {
+      "label": "Date",
       "legend": "Date on the letter",
       "hint": "For example, 11  6  2015"
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "body-parser": "^1.13.0",
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
-    "hmpo-form-wizard": "^1.0.1",
+    "hmpo-form-wizard": "^1.1.0",
     "hmpo-frontend-toolkit": "^1.2.1",
     "hmpo-govuk-template": "0.0.3",
     "hmpo-model": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "copy:images": "mkdir -p ./dist; cp -r ./assets/images ./dist/images",
     "style": "jscs **/*.js --config=./.jscsrc.json",
     "quality": "plato -r -x 'node_modules|reports|test' -d reports/plato .",
-    "postinstall": "npm run sass",
-    "sass": "node-sass ./assets/scss/app.scss ./dist/css/app.css --include-path ./node_modules"
+    "sass": "./node_modules/node-sass/bin/node-sass ./assets/scss/app.scss ./dist/css/app.css --include-path ./node_modules"
   },
   "author": "HomeOffice",
   "dependencies": {

--- a/routes/fields.js
+++ b/routes/fields.js
@@ -1,16 +1,6 @@
 'use strict';
 
 module.exports = {
-  received: {
-    display: 'inline',
-    options: [{
-      value: 'yes',
-      label: 'fields.received.options.yes.label'
-    }, {
-      value: 'no',
-      label: 'fields.received.options.no.label'
-    }]
-  },
   'continue': {
     value: 'buttons.continue'
   },
@@ -20,17 +10,31 @@ module.exports = {
   change: {
     value: 'buttons.change'
   },
+  received: {
+    validate: ['required'],
+    display: 'inline',
+    options: [{
+      value: 'yes',
+      label: 'fields.received.options.yes.label'
+    }, {
+      value: 'no',
+      label: 'fields.received.options.no.label'
+    }]
+  },
   'delivery-date': {
     legend: 'fields.delivery-date.legend',
     hint: 'fields.dalivery-date.hint'
   },
   'delivery-date-day': {
-    label: 'fields.delivery-date-day.label'
+    validate: ['required', 'numeric'],
+    label: 'fields.delivery-date-day.label',
   },
   'delivery-date-month': {
+    validate: ['required', 'numeric'],
     label: 'fields.delivery-date-month.label'
   },
   'delivery-date-year': {
+    validate: ['required', 'numeric'],
     label: 'fields.delivery-date-year.label'
   },
   'no-letter': {

--- a/routes/steps/delivery.js
+++ b/routes/steps/delivery.js
@@ -7,8 +7,10 @@ module.exports = {
     next: '/letter-received'
   },
   '/letter-received': {
+    controller: require('../../controllers/letter-received'),
     fields: [
       'received',
+      'delivery-date',
       'delivery-date-day',
       'delivery-date-month',
       'delivery-date-year'

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,6 +4,7 @@ globals:
   chai: true
   expect: true
   sinon: true
+  should: true
 rules:
   func-names: 0
   max-nested-callbacks: 0

--- a/test/unit/controllers/letter-received.js
+++ b/test/unit/controllers/letter-received.js
@@ -1,0 +1,162 @@
+'use strict';
+
+var Controller = require('hmpo-form-wizard').Controller;
+var ErrorClass = require('hmpo-form-wizard').Error;
+var LetterReceivedController = require('../../../controllers/letter-received');
+
+describe('controllers/letter-received', function () {
+
+  describe('.setErrors(err, req)', function () {
+
+    describe('with delivery date errors', function () {
+
+      var err = {
+        'delivery-date-day': {type: 'required'},
+        'delivery-date-month': false,
+        'delivery-date-year': {type: 'required'}
+      };
+
+      var controller;
+      var req = {};
+
+      beforeEach(function () {
+        Controller.prototype.setErrors = sinon.stub();
+        controller = new LetterReceivedController({template: 'index'});
+        controller.setErrors(err, req);
+      });
+
+      it('sets delivery-date required error with error properties', function () {
+        err['delivery-date'].should.be.an.instanceof(ErrorClass);
+        err['delivery-date'].should.have.property('key')
+          .and.equal('delivery-date');
+        err['delivery-date'].should.have.property('type')
+          .and.equal('required');
+        err['delivery-date'].should.have.property('redirect')
+          .and.equal(undefined);
+        err['delivery-date'].should.have.property('message');
+      });
+
+      it('calls setErrors on the parent controller with arguments', function() {
+        Controller.prototype.setErrors.should.have.been.calledWith(err, req);
+      });
+
+    });
+
+    describe('with only numeric delivery date errors', function () {
+
+      var err = {
+        'delivery-date-day': {type: 'numeric'},
+        'delivery-date-month': false,
+        'delivery-date-year': {type: 'numeric'}
+      };
+
+      var controller;
+      var req = {};
+
+      beforeEach(function () {
+        Controller.prototype.setErrors = sinon.stub();
+        controller = new LetterReceivedController({template: 'index'});
+        controller.setErrors(err, req);
+      });
+
+      it('sets delivery-date numeric error with error properties', function () {
+        err['delivery-date'].should.have.property('type')
+          .and.equal('numeric');
+      });
+
+      it('calls setErrors on the parent controller with arguments', function() {
+        Controller.prototype.setErrors.should.have.been.calledWith(err, req);
+      });
+
+    });
+
+    describe('letter not received', function () {
+
+      var err = {
+        'delivery-date-day': true,
+        'delivery-date-month': false,
+        'delivery-date-year': true
+      };
+
+      var controller;
+      var req = {
+        form: {
+          values: {
+            received: 'no'
+          }
+        }
+      };
+
+      beforeEach(function () {
+        Controller.prototype.setErrors = sinon.stub();
+        controller = new LetterReceivedController({template: 'index'});
+        controller.setErrors(err, req);
+      });
+
+      it('deletes all delivery date errors', function () {
+        should.not.exist(err['delivery-date']);
+        should.not.exist(err['delivery-date-day']);
+        should.not.exist(err['delivery-date-month']);
+        should.not.exist(err['delivery-date-year']);
+      });
+
+      it('calls setErrors on the parent controller with arguments', function() {
+        Controller.prototype.setErrors.should.have.been.calledWith(err, req);
+      });
+
+    });
+
+  });
+
+  describe('.validateField(key, req)', function () {
+
+    describe('when letter has not been received', function () {
+
+      var controller;
+      var key = 'delivery-date-year';
+      var req = {
+        form: {
+          values: {
+            received: 'no'
+          }
+        }
+      };
+
+      beforeEach(function () {
+        controller = new LetterReceivedController({template: 'index'});
+      });
+
+
+      it('does not validate delivery date values', function () {
+        should.equal(controller.validateField(key, req), undefined);
+      });
+
+    });
+
+    describe('when letter has been received', function () {
+
+      var controller;
+      var key = 'delivery-date-year';
+      var req = {
+        form: {
+          values: {
+            received: 'yes'
+          }
+        }
+      };
+
+      beforeEach(function () {
+        Controller.prototype.validateField = sinon.stub();
+        controller = new LetterReceivedController({template: 'index'});
+        controller.validateField(key, req);
+      });
+
+      it('calls the validateField method on the parent controller with arguments', function () {
+        Controller.prototype.validateField.should.have.been.calledWith(key, req);
+      });
+
+    });
+
+  });
+
+});

--- a/views/pages/letter-received.html
+++ b/views/pages/letter-received.html
@@ -1,5 +1,10 @@
 {{<layout}}
   {{$step}}Step 1 of 5{{/step}}
+
+  {{$validationSummary}}
+    {{> partials-validation-summary}}
+  {{/validationSummary}}
+
   {{$propositionHeader}}
     {{> partials-navigation}}
   {{/propositionHeader}}
@@ -18,19 +23,27 @@
     {{<partials-form}}
 
       {{$form}}
-
         {{#radio-group}}received{{/radio-group}}
 
-        <fieldset id="dated-group" class="panel-indent">
+        <fieldset id="delivery-date-group" class="panel-indent {{#errors.delivery-date}}validation-error{{/errors.delivery-date}}">
+
           <legend class="visuallyhidden">
-              <span class="form-label-bold">{{#t}}fields.delivery-date.legend{{/t}}</span>
+            <span class="form-label-bold">{{#t}}fields.delivery-date.legend{{/t}}</span>
           </legend>
 
           <p>{{#t}}steps.one.date-question{{/t}}</p>
 
+          {{#errors.delivery-date}}
+            <span id="delivery-date-error" class="error-message">
+              {{errors.delivery-date.message}}
+            </span>
+          {{/errors.delivery-date}}
+
           <div class="form-group form-date">
-              <p id="delivery-date-hint" class="form-hint">{{#t}}fields.delivery-date.hint{{/t}}</p>
-              {{#input-date}}delivery-date{{/input-date}}
+            <p id="delivery-date-hint" class="form-hint">
+              {{#t}}fields.delivery-date.hint{{/t}}
+            </p>
+            {{#input-date}}delivery-date{{/input-date}}
           </div>
 
           {{#checkbox}}no-letter{{/checkbox}}

--- a/views/partials/validation-summary.html
+++ b/views/partials/validation-summary.html
@@ -1,5 +1,6 @@
 {{#errorlist.length}}
 <div class="validation-summary" tabindex="-1">
+    {{$errorlist-title}}<h2>{{#t}}errorlist.title{{/t}}</h2>{{/errorlist-title}}
     {{<partials-validation-list}}
         {{$validation-list}}
             {{#errorlist}}


### PR DESCRIPTION
 This pr covers the validation display of error messages for the initial form page of the `undelivered` journey.

Items validated:
- is the letter received radio buttons: a user must select a button.
- if the user selects no to the previous control, then the date is validated: date is required and must be numeric.

Error messages are displayed at field level where appropriate and in a list at the top of the form/page