### PR TITLE
Add run.sh for assets contents copying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN npm install
 COPY . /brp_app
 
 EXPOSE 8080
-CMD npm start
+CMD /brp_app/run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# copy assets over to /assets for nginx container to serve, only copy if /assets
+# directory exists, which implies that kubernetes volume has been mounted
+ASSETS_DIR='/assets'
+if [[ -d ${ASSETS_DIR} ]] && [[ ! $(ls -A ${ASSETS_DIR}) ]]; then
+  cp -r /brp_app/assets/ /
+fi
+
+npm start


### PR DESCRIPTION
Contents of the `assets` directory have to be copied on to a volume which kubernetes creates for a pod. nginx container in the same pod will then serve static assets.