### PR TITLE
node 0.12.7 and fix assets copying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vaijab/nodejs:0.12.6
+FROM vaijab/nodejs:0.12.7
 
 RUN useradd -d /app app
 USER app
@@ -9,6 +9,7 @@ COPY assets /app/assets
 RUN npm install
 COPY . /app
 
+USER root
 EXPOSE 8080
 CMD /app/run.sh
 


### PR DESCRIPTION
Unfortunately we're going to have to run node as root, because run.sh
needs to be able to copy assets to /public which is owned by root.