### PR TITLE
DSP-96: lost or stolen confirmation content variations

### DIFF
--- a/controllers/confirmation.js
+++ b/controllers/confirmation.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var util = require('util');
+var Controller = require('hmpo-form-wizard').Controller;
+
+var ConfirmationController = function ConfirmationController() {
+  Controller.apply(this, arguments);
+};
+
+util.inherits(ConfirmationController, Controller);
+
+function getLocationLocal(req) {
+  if (req.form.values['inside-uk'] === 'yes') {
+    return {
+      'inside-uk': true
+    };
+  }
+  if (req.form.values['inside-uk'] === 'no') {
+    return {
+      'outside-uk': true
+    };
+  }
+  return {
+    'not-specified': true
+  };
+}
+
+Controller.prototype.locals = function confirmationLocals(req, res) {
+  return {
+    baseUrl: req.baseUrl,
+    nextPage: this.getNextStep(req, res),
+    location: getLocationLocal(req)
+  };
+};
+
+module.exports = ConfirmationController;

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -412,10 +412,26 @@
       "email": "We have sent you an email containing the information you have provided to",
       "next": {
         "title": "What happens next",
-        "para": {
-          "one": "We will now review the information you provided to find out why you have not received the biometric residence permit.",
-          "two": "We will get back to you within 5 working days. For example, if you contact us on a Monday you will hear back by the following Monday.",
-          "three": "We will then advise you what to do next."
+        "not-specified": {
+          "para": {
+            "one": "We will now review the information you provided to find out why you have not received the biometric residence permit.",
+            "two": "We will get back to you within 5 working days. For example, if you contact us on a Monday you will hear back by the following Monday.",
+            "three": "We will then advise you what to do next."
+          }
+        },
+        "inside-uk": {
+          "para": {
+            "one": "You should hear from us in the next working day, where we will advise you what to do.",
+            "two": "You may need to <a href=''>apply for a replacement</a> biometric residence permit."
+          }
+        },
+        "outside-uk": {
+          "para": {
+            "one": "You should hear from us in the next working day, where we will advise you what to do.",
+            "two": "As you are outside the UK you may need to apply for a temporary ‘replacement BRP visa’ which you can use once to re-enter the UK. A replacement BRP visa costs £72.",
+            "three": "You must apply online for a replacement BRP visa in most countries. https://www.gov.uk/apply-uk-visa.",
+            "four": "When you are back in UK you should then apply for a replacement BRP within 1 month."
+          }
         }
       }
     },

--- a/routes/steps/delivery.js
+++ b/routes/steps/delivery.js
@@ -71,6 +71,7 @@ module.exports = {
     next: '/confirmation'
   },
   '/confirmation': {
+    controller: require('../../controllers/confirmation'),
     backLink: false,
     next: '/done'
   },

--- a/routes/steps/error.js
+++ b/routes/steps/error.js
@@ -89,6 +89,7 @@ module.exports = {
     next: '/confirmation'
   },
   '/confirmation': {
+    controller: require('../../controllers/confirmation'),
     backLink: false,
     next: '/done'
   },

--- a/routes/steps/lost.js
+++ b/routes/steps/lost.js
@@ -64,6 +64,7 @@ module.exports = {
     next: '/confirmation'
   },
   '/confirmation': {
+    controller: require('../../controllers/confirmation'),
     backLink: false,
     next: '/done'
   },

--- a/test/unit/controllers/confirmation.js
+++ b/test/unit/controllers/confirmation.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var Controller = require('hmpo-form-wizard').Controller;
+var ConfirmationController = require('../../../controllers/confirmation');
+
+describe('controllers/confirmation', function () {
+
+  beforeEach(function () {
+    Controller.prototype.getNextStep = sinon.stub();
+  });
+
+  describe('when the user is outside the uk', function () {
+
+    var req = {
+      form: {
+        values: {
+          'inside-uk': 'no'
+        }
+      }
+    };
+    var res = {};
+    var controller;
+
+    beforeEach(function () {
+      controller = new ConfirmationController({template: 'foo'});
+    });
+
+    it('locals.location is ouside-uk', function () {
+      var preparedLocals = controller.locals(req, res);
+
+      preparedLocals.should.have.property('location')
+        .and.deep.equal({'outside-uk': true});
+
+    });
+
+  });
+
+  describe('when the user is inside the uk', function () {
+
+    var req = {
+      form: {
+        values: {
+          'inside-uk': 'yes'
+        }
+      }
+    };
+    var res = {};
+    var controller;
+
+    beforeEach(function () {
+      controller = new ConfirmationController({template: 'foo'});
+    });
+
+    it('locals.location is inside-uk', function () {
+      var preparedLocals = controller.locals(req, res);
+
+      preparedLocals.should.have.property('location')
+        .and.deep.equal({'inside-uk': true});
+
+    });
+
+  });
+
+  describe('when the user is neither inside the uk or outside the uk', function () {
+
+    var req = {
+      form: {
+        values: {}
+      }
+    };
+    var res = {};
+    var controller;
+
+    beforeEach(function () {
+      controller = new ConfirmationController({template: 'foo'});
+    });
+
+    it('locals.location is not-specified', function () {
+      var preparedLocals = controller.locals(req, res);
+
+      preparedLocals.should.have.property('location')
+        .and.deep.equal({'not-specified': true});
+
+    });
+
+  });
+
+});

--- a/views/pages/check-details-error.html
+++ b/views/pages/check-details-error.html
@@ -160,6 +160,11 @@
         </tr>
       </table>
 
+      <h2>{{#t}}pages.check-details.org-help.title{{/t}}</h2>
+      <p>{{#t}}pages.check-details.org-help.explanation{{/t}}</p>
+
+      {{#radio-group}}org-help{{/radio-group}}
+
       <fieldset id="org-details-group">
         {{#input-text}}rep-name{{/input-text}}
         {{#input-text}}organisation{{/input-text}}

--- a/views/pages/confirmation-lost.html
+++ b/views/pages/confirmation-lost.html
@@ -1,0 +1,30 @@
+{{<layout}}
+
+{{$propositionHeader}}
+  {{> partials-navigation}}
+{{/propositionHeader}}
+
+{{$content}}
+  <div class="alert-complete" role="alert">
+    <span class="icon icon-complete" role="presentation"></span>
+    <div class="alert-message">
+      <h1>{{#t}}pages.confirmation.header{{/t}}</h1>
+    </div>
+  </div>
+  <p>{{#t}}pages.confirmation.privacy{{/t}}</p>
+
+  <hr>
+  <p>{{#t}}pages.confirmation.email{{/t}}</p>
+  <hr>
+  <h3>{{#t}}pages.confirmation.next.title{{/t}}</h3>
+  <p>{{#t}}pages.confirmation.next.para.one{{/t}}</p>
+  <p>{{#t}}pages.confirmation.next.para.two{{/t}}</p>
+  <p>{{#t}}pages.confirmation.next.para.three{{/t}}</p>
+
+  <hr>
+
+  <a href='/'>Finish</a>
+
+{{/content}}
+
+{{/layout}}

--- a/views/pages/confirmation.html
+++ b/views/pages/confirmation.html
@@ -14,12 +14,28 @@
   <p>{{#t}}pages.confirmation.privacy{{/t}}</p>
 
   <hr>
+
   <p>{{#t}}pages.confirmation.email{{/t}}</p>
+
   <hr>
+
   <h3>{{#t}}pages.confirmation.next.title{{/t}}</h3>
-  <p>{{#t}}pages.confirmation.next.para.one{{/t}}</p>
-  <p>{{#t}}pages.confirmation.next.para.two{{/t}}</p>
-  <p>{{#t}}pages.confirmation.next.para.three{{/t}}</p>
+
+  {{#location.inside-uk}}
+    <p>{{#t}}pages.confirmation.next.inside-uk.para.one{{/t}}</p>
+    <p>{{#t}}pages.confirmation.next.inside-uk.para.two{{/t}}</p>
+  {{/location.inside-uk}}
+
+  {{#location.outside-uk}}
+    <p>{{#t}}pages.confirmation.next.outside-uk.para.one{{/t}}</p>
+    <p>{{#t}}pages.confirmation.next.outside-uk.para.two{{/t}}</p>
+  {{/location.outside-uk}}
+
+  {{#location.not-specified}}
+    <p>{{#t}}pages.confirmation.next.not-specified.para.one{{/t}}</p>
+    <p>{{#t}}pages.confirmation.next.not-specified.para.two{{/t}}</p>
+    <p>{{#t}}pages.confirmation.next.not-specified.para.three{{/t}}</p>
+  {{/location.not-specified}}
 
   <hr>
 


### PR DESCRIPTION
- add confirmation controller to serve locals for location setting
- add confirmation translations and format consistently
- add new confirmation controller to each journey

- add check-details-error template org-help form control

![](https://s3.amazonaws.com/giphygifs/media/10zi9Pi3iVtX7W/giphy.gif)