### PR TITLE
Base Constructors - easier extension

### DIFF
--- a/controllers/about-error.js
+++ b/controllers/about-error.js
@@ -2,8 +2,8 @@
 
 var util = require('util');
 var DateController = require('../lib/date-controller');
-var Controller = require('hmpo-form-wizard').Controller;
-var ErrorClass = require('hmpo-form-wizard').Error;
+var Controller = require('../lib/base-wizard').Controller;
+var ErrorClass = require('../lib/base-wizard').Error;
 var moment = require('moment');
 var _ = require('underscore');
 

--- a/controllers/check-details.js
+++ b/controllers/check-details.js
@@ -3,7 +3,7 @@
 var util = require('util');
 var _ = require('underscore');
 
-var Controller = require('hmpo-form-wizard').Controller;
+var Controller = require('../lib/base-wizard').Controller;
 var Model = require('../models/email');
 
 var Submit = function Submit() {

--- a/controllers/confirmation.js
+++ b/controllers/confirmation.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('util');
-var Controller = require('hmpo-form-wizard').Controller;
+var Controller = require('../lib/base-wizard').Controller;
 
 var ConfirmationController = function ConfirmationController() {
   Controller.apply(this, arguments);

--- a/controllers/contact-details.js
+++ b/controllers/contact-details.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('util');
-var Controller = require('hmpo-form-wizard').Controller;
+var Controller = require('../lib/base-wizard').Controller;
 
 var ContactDetails = function ContactDetails() {
   Controller.apply(this, arguments);

--- a/controllers/letter-received.js
+++ b/controllers/letter-received.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('util');
-var Controller = require('hmpo-form-wizard').Controller;
+var Controller = require('../lib/base-wizard').Controller;
 var DateController = require('../lib/date-controller');
 var debug = require('debug')('controllers/letter-recieved');
 

--- a/controllers/on-the-way.js
+++ b/controllers/on-the-way.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('util');
-var Controller = require('hmpo-form-wizard').Controller;
+var Controller = require('../lib/base-wizard').Controller;
 
 var OnTheWay = function OnTheWayController() {
   Controller.apply(this, arguments);

--- a/controllers/same-address.js
+++ b/controllers/same-address.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var util = require('util');
-var Controller = require('hmpo-form-wizard').Controller;
-var debug = require('debug');
+var Controller = require('../lib/base-wizard').Controller;
+var debug = require('debug')('controllers:same-address');
 
 var SameAddressController = function SameAddressController() {
   Controller.apply(this, arguments);

--- a/controllers/start.js
+++ b/controllers/start.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('util');
-var Controller = require('hmpo-form-wizard').Controller;
+var Controller = require('../lib/base-wizard').Controller;
 
 var Start = function Start() {
   Controller.apply(this, arguments);

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var Controller = require('hmpo-form-wizard').Controller;
+
+function getErrorLength() {
+  var errors = this.getErrors.apply(this, arguments);
+  var errorLength = Object.keys(errors).length;
+
+  if (errorLength === 1) {
+    return {
+      single: true
+    };
+  }
+  if (errorLength > 1) {
+    return {
+      multiple: true
+    };
+  }
+}
+
+Controller.prototype.locals = function controllerLocals(req, res) {
+  return {
+    baseUrl: req.baseUrl,
+    nextPage: this.getNextStep(req, res),
+    errorLength: getErrorLength.apply(this, arguments)
+  };
+};
+
+module.exports = Controller;

--- a/lib/base-error.js
+++ b/lib/base-error.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var ErrorClass = require('hmpo-form-wizard').Error;
+
+module.exports = ErrorClass;

--- a/lib/base-wizard.js
+++ b/lib/base-wizard.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var wizard = require('hmpo-form-wizard');
+
+wizard.Controller = require('./base-controller');
+wizard.Error = require('./base-error');
+
+module.exports = wizard;

--- a/lib/date-controller.js
+++ b/lib/date-controller.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var util = require('util');
-var Controller = require('hmpo-form-wizard').Controller;
-var ErrorClass = require('hmpo-form-wizard').Error;
+var Controller = require('../lib/base-wizard').Controller;
+var ErrorClass = require('../lib/base-wizard').Error;
 var moment = require('moment');
 var _ = require('underscore');
 var debug = require('debug')('lib:date-controller');

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -7,7 +7,10 @@
     "close": "Close"
   },
   "errorlist": {
-    "title": "Please fix the following error(s)"
+    "title": {
+      "single": "Please fix the following error",
+      "multiple": "Please fix the following errors"
+    }
   },
   "validation": {
     "delivery-date": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,7 +5,7 @@ var deliverySteps = require('./steps/delivery');
 var errorSteps = require('./steps/error');
 var lostSteps = require('./steps/lost');
 var fields = require('./fields');
-var wizard = require('hmpo-form-wizard');
+var wizard = require('../lib/base-wizard');
 var mixins = require('hmpo-template-mixins');
 var i18n = require('i18n-future')();
 

--- a/test/unit/lib/date-controller.js
+++ b/test/unit/lib/date-controller.js
@@ -9,7 +9,7 @@ wizard.Controller.prototype.validateField = sinon.stub();
 var moment = require('moment');
 var proxyquire = require('proxyquire');
 var DateController = proxyquire('../../../lib/date-controller', {
-  'hmpo-form-wizard': wizard
+  '../lib/base-wizard': wizard
 });
 var ErrorClass = require('hmpo-form-wizard').Error;
 

--- a/views/partials/validation-summary.html
+++ b/views/partials/validation-summary.html
@@ -1,6 +1,16 @@
 {{#errorlist.length}}
 <div class="validation-summary" tabindex="-1">
-    {{$errorlist-title}}<h2>{{#t}}errorlist.title{{/t}}</h2>{{/errorlist-title}}
+    {{$errorlist-title}}
+
+      {{#errorLength.single}}
+        <h2>{{#t}}errorlist.title.single{{/t}}</h2>
+      {{/errorLength.single}}
+      {{#errorLength.multiple}}
+        <h2>{{#t}}errorlist.title.multiple{{/t}}</h2>
+      {{/errorLength.multiple}}
+
+    {{/errorlist-title}}
+
     {{<partials-validation-list}}
         {{$validation-list}}
             {{#errorlist}}


### PR DESCRIPTION
- add base-error, base-wizard, and base-controller modules
- hook base wizard to routes
- rewire custom constructors to base-controller and base-error where apt.

- override controller.prototype.locals to provide error list length to view
- update validation summary view to conditionally display apt message
- add/amend errorlist messages in locales