### PR TITLE
Allow multiple caseworker email addresses to be supported in the application

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,7 +16,12 @@ module.exports = {
     host: process.env.REDIS_HOST || '127.0.0.1'
   },
   email: {
-    caseworker: process.env.CASEWORKER_EMAIL || 'caseworker_email_address',
+    caseworker: {
+      error: process.env.CASEWORKER_ERROR_EMAIL || 'caseworker_email_address',
+      'lost-or-stolen-uk': process.env.CASEWORKER_LOSTSTOLEN_EMAIL || 'caseworker_email_address',
+      'lost-or-stolen-abroad': process.env.CASEWORKER_LOSTSTOLEN_EMAIL || 'caseworker_email_address',
+      delivery: process.env.CASEWORKER_DELIVERY_EMAIL || 'caseworker_email_address'
+    },
     port: process.env.EMAIL_PORT || 587,
     host: process.env.EMAIL_HOST || 'email-smtp.eu-west-1.amazonaws.com',
     auth: {

--- a/documentation/ENVIRONMENT_VARIABLES.md
+++ b/documentation/ENVIRONMENT_VARIABLES.md
@@ -11,7 +11,9 @@
 ### Email service environment variables
 (Will be removed from the app when the email service is created)
 
-* `CASEWORKER_EMAIL` email for caseworker. Defaults to broken 'caseworker_email_address'.
+* `CASEWORKER_ERROR_EMAIL` caseworker email for the correct-mistakes journey. Defaults to broken 'caseworker_email_address'.
+* `CASEWORKER_LOSTSTOLEN_EMAIL` caseworker email for the lost-stolen journey. Defaults to broken 'caseworker_email_address'.
+* `CASEWORKER_DELIVERY_EMAIL` caseworker email for the not-arrived journey. Defaults to broken 'caseworker_email_address'.
 * `EMAIL_PORT` email port. Defaults to 587.
 * `EMAIL_HOST` smtp host. Defaults to 'email-smtp.eu-west-1.amazonaws.com'.
 * `SMTP_USER` smtp username. Defaults to ''.

--- a/services/email/index.js
+++ b/services/email/index.js
@@ -108,7 +108,7 @@ Emailer.prototype.send = function send(email, callback) {
 
   this.transporter.sendMail({
     from: config.email.from,
-    to: config.email.caseworker,
+    to: config.email.caseworker[email.template],
     subject: email.subject,
     text: Mustache.render(caseworkerPlainTextTemplates[email.template], templateData),
     html: Mustache.render(caseworkerHtmlTemplates[email.template], templateData),


### PR DESCRIPTION
This sets up the env variables we need for the three caseworker emails.

If no env var is set up it uses a broken caseworker address.

Updated docs.