### PR TITLE
Disable logging when running tests in a ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ cache:
   directories:
     - node_modules
 
-script: "npm run test:ci && npm run sass; NODE_ENV='travis' npm start& npm run test:acceptance"
+script: "npm run test:ci && npm run sass; NODE_ENV='ci' npm start& npm run test:acceptance"

--- a/app.js
+++ b/app.js
@@ -11,7 +11,9 @@ var RedisStore = require('connect-redis-crypto')(session);
 var config = require('./config');
 require('moment-business');
 
-app.use(churchill(logger));
+if (config.env !== 'ci') {
+  app.use(churchill(logger));
+}
 
 if (config.env === 'development') {
   app.use('/public', express.static(path.resolve(__dirname, './public')));


### PR DESCRIPTION
Changed the NODE_ENV from travis to ci to be less tied into using travis.