### PR TITLE
Eliminate reliance on Bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "style": "jscs **/*.js --config=./.jscsrc.json",
     "quality": "plato -r -x 'node_modules|reports|test' -d reports/plato .",
     "sass": "./node_modules/node-sass/bin/node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",
-    "create:public": "mkdir -p ./public/{js,css,images};",
+    "create:public": "mkdir -p ./public/js ./public/css ./public/images",
     "postinstall": "npm run create:public; npm run sass; npm run browserify; npm run copy:images"
   },
   "author": "HomeOffice",


### PR DESCRIPTION
Replaces the brace expansion in the create:public script in package.json.

Brace expansions are a Bash extension. npm runs its scripts through sh not bash.
On most modern GNU/Linux distributions sh is symlinked to bash which is why the
brace expansion will work in most cases. However, this is not always the case;
for example Ubuntu symlinks sh to dash which does not support bash completion.
This means that 'npm run create:public' fails and with it 'npm install'.