### PR TITLE
Enable single line JSON output

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -22,7 +22,10 @@ loggingTransports.push(
   new (winston.transports.Console)({
     json: (notProd === true) ? false : true,
     timestamp: true,
-    colorize: true
+    colorize: true,
+    stringify: function stringify(obj) {
+      return JSON.stringify(obj);
+    }
   })
 );
 
@@ -30,7 +33,10 @@ exceptionTransports.push(
   new (winston.transports.Console)({
     json: (notProd === true) ? false : true,
     timestamp: true,
-    colorize: true
+    colorize: true,
+    stringify: function stringify(obj) {
+      return JSON.stringify(obj);
+    }
   })
 );
 


### PR DESCRIPTION
Makes easy parsing of logging by other tools.

Closes #226 