### PR TITLE
DSP-242: Remove dependencies that have been repalced with HOF

### DIFF
--- a/apps/common/models/email.js
+++ b/apps/common/models/email.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var emailService = require('../../../services/email');
-var Model = require('hmpo-model');
+var Model = require('hof').Model;
 var _ = require('underscore');
 
 function EmailModel() {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,8 +1,13 @@
 'use strict';
 
-var helpers = require('hmpo-frontend-toolkit').helpers;
-var progressiveReveal = require('hmpo-frontend-toolkit').progressiveReveal;
-var formFocus = require('hmpo-frontend-toolkit').formFocus;
+// In package.json: hof points to toolkit
+// "browser": {
+//    "hof": "hmpo-frontend-toolkit"
+//  }
+var toolkit = require('hof');
+var helpers = toolkit.helpers;
+var progressiveReveal = toolkit.progressiveReveal;
+var formFocus = toolkit.formFocus;
 
 helpers.documentReady(progressiveReveal);
 helpers.documentReady(formFocus);

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,6 +1,6 @@
 $path: "../img/";
 
-@import "../../node_modules/hmpo-frontend-toolkit/assets/stylesheets/app.scss";
+@import "../../node_modules/hof/node_modules/hmpo-frontend-toolkit/assets/stylesheets/app.scss";
 
 @import "./alert.scss";
 @import "./icons.scss";

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./apps/common/translations/src",
     "postinstall": "npm run create:public; npm run sass; npm run browserify; npm run copy:images; npm run hof-transpile"
   },
+  "browser": {
+    "hof": "hmpo-frontend-toolkit"
+  },
   "author": "HomeOffice",
   "dependencies": {
     "body-parser": "^1.13.0",
@@ -32,16 +35,9 @@
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.11.3",
-    "hmpo-form-wizard": "git+https://github.com/UKHomeOffice/passports-form-wizard.git#5e5a6b077c0449dbc5aacd9ebf610f6fa4427d2c",
-    "hmpo-frontend-toolkit": "^1.2.1",
-    "hmpo-govuk-template": "0.0.3",
-    "hmpo-model": "^0.1.2",
-    "hmpo-template-mixins": "^1.1.0",
     "hof": "0.0.1",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",
-    "i18n-future": "^0.1.4",
-    "i18n-lookup": "^0.1.0",
     "jquery": "^2.1.4",
     "moment": "^2.10.3",
     "moment-business": "^2.0.0",

--- a/services/email/index.js
+++ b/services/email/index.js
@@ -3,9 +3,10 @@
 var logger = require('../../lib/logger');
 var nodemailer = require('nodemailer');
 var config = require('../../config');
-var i18n = require('i18n-future')();
+var hof = require('hof');
+var i18n = hof.i18n();
 var Hogan = require('hogan.js');
-var lookup = require('i18n-lookup')(i18n.translate.bind(i18n));
+var lookup = hof.i18nLookup(i18n.translate.bind(i18n));
 var fs = require('fs');
 var path = require('path');
 

--- a/test/unit/apps/common/models/email.js
+++ b/test/unit/apps/common/models/email.js
@@ -8,10 +8,12 @@ var emailService = {
 describe('apps/common/models/email', function () {
 
   describe('instantiated', function () {
-    var Model = sinon.stub();
+    var hof = {
+      Model: sinon.stub()
+    };
     var EmailModel = proxyquire('../../../../../apps/common/models/email', {
       '../../../services/email': emailService,
-      'hmpo-model': Model
+      'hof': hof
     });
 
     it('calls hmpo-model Model with the arguments', function () {
@@ -21,7 +23,7 @@ describe('apps/common/models/email', function () {
       /*eslint no-unused-vars: 0*/
       var model = new EmailModel(emailData);
       /*eslint no-unused-vars: 1*/
-      Model.should.have.been.calledWith(emailData);
+      hof.Model.should.have.been.calledWith(emailData);
     });
   });
 


### PR DESCRIPTION
- remove dependencies from BRP that are installed via HOF
- update @import path in app.scss
- update all paths to node_modules/hof...
- use browser field in BRP to point hof at hmpo-frontend-toolkit for browserify