### PR TITLE
Only send the emails when the translation file has loaded.

### DIFF
--- a/services/email/index.js
+++ b/services/email/index.js
@@ -93,77 +93,81 @@ function Emailer() {
 
 Emailer.prototype.send = function send(email, callback) {
   var locali18n = i18n({
-    path: path.resolve(__dirname, '../../apps/', './' + translationLocation[email.template] ,'./translations/__lng__/__ns__.json')
+    path: path.resolve(
+      __dirname, '../../apps/', './' + translationLocation[email.template] ,'./translations/__lng__/__ns__.json'
+    )
   });
-  var lookup = i18nLookup(locali18n.translate.bind(locali18n));
-  var templateData = {
-    data: email.dataToSend,
-    t: function t() {
-      return function lookupTranslation(translate) {
-        // for translations inside our mustache templates
-        return lookup(Hogan.compile(translate).render(email.dataToSend));
-      };
-    }
-  };
 
-  function sendCustomerEmail() {
-    logger.info('Emailing customer: ', email.subject);
-
-    if (email.to) {
-      this.transporter.sendMail({
-        from: config.email.from,
-        to: email.to,
-        subject: email.subject,
-        text: Hogan.compile(customerPlainTextTemplates[email.template]).render(templateData),
-        html: Hogan.compile(customerHtmlTemplates[email.template]).render(templateData),
-        attachments: [
-          {
-            filename: 'govuk_logotype_email.png',
-            path: path.resolve(__dirname, './images/govuk_logotype_email.png'),
-            cid: 'govuk_logotype_email'
-          },
-          {
-            filename: 'ho_crest_27px.png',
-            path: path.resolve(__dirname, './images/ho_crest_27px.png'),
-            cid: 'ho_crest_27px'
-          },
-          {
-            filename: 'spacer.gif',
-            path: path.resolve(__dirname, './images/spacer.gif'),
-            cid: 'spacer_image'
-          }
-        ]
-      }, callback);
-    } else {
-      callback();
-    }
-  }
-
-  logger.info('Emailing caseworker: ', email.subject);
-  this.transporter.sendMail({
-    from: config.email.from,
-    to: config.email.caseworker[email.template],
-    subject: email.subject,
-    text: Hogan.compile(caseworkerPlainTextTemplates[email.template]).render(templateData),
-    html: Hogan.compile(caseworkerHtmlTemplates[email.template]).render(templateData),
-    attachments: [
-      {
-        filename: 'govuk_logotype_email.png',
-        path: path.resolve(__dirname, './images/govuk_logotype_email.png'),
-        cid: 'govuk_logotype_email'
-      },
-      {
-        filename: 'ho_crest_27px.png',
-        path: path.resolve(__dirname, './images/ho_crest_27px.png'),
-        cid: 'ho_crest_27px'
-      },
-      {
-        filename: 'spacer.gif',
-        path: path.resolve(__dirname, './images/spacer.gif'),
-        cid: 'spacer_image'
+  locali18n.on('ready', function locali18nLoaded () {
+    var lookup = i18nLookup(locali18n.translate.bind(locali18n));
+    var templateData = {
+      data: email.dataToSend,
+      t: function t() {
+        return function lookupTranslation(translate) {
+          // for translations inside our mustache templates
+          return lookup(Hogan.compile(translate).render(email.dataToSend));
+        };
       }
-    ]
-  }, sendCustomerEmail.bind(this));
+    };
+
+    function sendCustomerEmail() {
+      if (email.to) {
+        logger.info('Emailing customer: ', email.subject);
+        this.transporter.sendMail({
+          from: config.email.from,
+          to: email.to,
+          subject: email.subject,
+          text: Hogan.compile(customerPlainTextTemplates[email.template]).render(templateData),
+          html: Hogan.compile(customerHtmlTemplates[email.template]).render(templateData),
+          attachments: [
+            {
+              filename: 'govuk_logotype_email.png',
+              path: path.resolve(__dirname, './images/govuk_logotype_email.png'),
+              cid: 'govuk_logotype_email'
+            },
+            {
+              filename: 'ho_crest_27px.png',
+              path: path.resolve(__dirname, './images/ho_crest_27px.png'),
+              cid: 'ho_crest_27px'
+            },
+            {
+              filename: 'spacer.gif',
+              path: path.resolve(__dirname, './images/spacer.gif'),
+              cid: 'spacer_image'
+            }
+          ]
+        }, callback);
+      } else {
+        callback();
+      }
+    }
+
+    logger.info('Emailing caseworker: ', email.subject);
+    this.transporter.sendMail({
+      from: config.email.from,
+      to: config.email.caseworker[email.template],
+      subject: email.subject,
+      text: Hogan.compile(caseworkerPlainTextTemplates[email.template]).render(templateData),
+      html: Hogan.compile(caseworkerHtmlTemplates[email.template]).render(templateData),
+      attachments: [
+        {
+          filename: 'govuk_logotype_email.png',
+          path: path.resolve(__dirname, './images/govuk_logotype_email.png'),
+          cid: 'govuk_logotype_email'
+        },
+        {
+          filename: 'ho_crest_27px.png',
+          path: path.resolve(__dirname, './images/ho_crest_27px.png'),
+          cid: 'ho_crest_27px'
+        },
+        {
+          filename: 'spacer.gif',
+          path: path.resolve(__dirname, './images/spacer.gif'),
+          cid: 'spacer_image'
+        }
+      ]
+    }, sendCustomerEmail.bind(this));
+  }.bind(this));
 };
 
 module.exports = new Emailer();


### PR DESCRIPTION
This was causing bugs on the emails as the translation file was not loaded when the first email was being sent.

Only has become and issue now as we dynamically load translations based on the journey.