### PR TITLE
Remove passport number from customer emails.

### DIFF
--- a/.nodemonignore
+++ b/.nodemonignore
@@ -1,1 +1,2 @@
 test
+node_modules

--- a/services/email/templates/customer/html/collection.mus
+++ b/services/email/templates/customer/html/collection.mus
@@ -141,7 +141,7 @@
                     {{#passport}}
                       <tr style="border-top: 1px solid #009390;">
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{passport}}</p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">XXXXXXXXX</p></td>
                       </tr>
                     {{/passport}}
                     {{#email}}

--- a/services/email/templates/customer/html/delivery.mus
+++ b/services/email/templates/customer/html/delivery.mus
@@ -95,7 +95,7 @@
                     {{#passport}}
                       <tr style="border-top: 1px solid #009390;">
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{passport}}</p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">XXXXXXXXX</p></td>
                       </tr>
                     {{/passport}}
                     {{#email}}

--- a/services/email/templates/customer/html/someone-else.mus
+++ b/services/email/templates/customer/html/someone-else.mus
@@ -97,7 +97,7 @@
                     {{#passport}}
                       <tr style="border-top: 1px solid #009390;">
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{passport}}</p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">XXXXXXXXX</p></td>
                       </tr>
                     {{/passport}}
                     {{#email}}

--- a/services/email/templates/customer/plain/collection.mus
+++ b/services/email/templates/customer/plain/collection.mus
@@ -75,7 +75,7 @@
 
   {{#passport}}
   {{#t}}pages.check-details.table.headers.passport{{/t}}
-  {{passport}}
+  XXXXXXXXX
   {{/passport}}
 
   {{#phone}}

--- a/services/email/templates/customer/plain/delivery.mus
+++ b/services/email/templates/customer/plain/delivery.mus
@@ -29,8 +29,8 @@
   {{nationality}}
 
   {{#passport}}
-    {{#t}}pages.check-details.table.headers.passport{{/t}}
-    {{passport}}
+  {{#t}}pages.check-details.table.headers.passport{{/t}}
+  XXXXXXXXX
   {{/passport}}
 
   {{#contact-address-street}}

--- a/services/email/templates/customer/plain/someone-else.mus
+++ b/services/email/templates/customer/plain/someone-else.mus
@@ -47,7 +47,7 @@
 
   {{#passport}}
   {{#t}}pages.check-details.table.headers.passport{{/t}}
-  {{passport}}
+  XXXXXXXXX
   {{/passport}}
 
   {{#phone}}


### PR DESCRIPTION
This is a security concern in case the user typos their email address.