### PR TITLE
Update hof to the latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.11.3",
-    "hof": "1.0.5",
+    "hof": "1.0.6",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",
     "jquery": "^2.1.4",


### PR DESCRIPTION
This removes the circular dependency in hof with hof-controllers and hof.

Stops quay failing as the previous version required git.