### PR TITLE
Add new hof-transpile step to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json /app/package.json
 COPY assets /app/assets
 RUN npm install
 COPY . /app
+RUN npm run hof-transpile
 
 USER root
 EXPOSE 8080


### PR DESCRIPTION
As we copy the app after the npm install the translations don't exist yet so transpile wasn't working

In order to keep docker caching the image quickly we don't want to npm install after copying the app so we're just adding this step afterwards (quicker docker images).