### PR TITLE
should allow us to run as root.  Needs tested

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM vaijab/nodejs:0.12.7
 
 RUN useradd -d /app app
-USER app
+RUN mkdir -p /public
 
 WORKDIR /app
 COPY package.json /app/package.json
@@ -9,8 +9,9 @@ COPY assets /app/assets
 RUN npm install
 COPY . /app
 
-USER root
+RUN chown -R app:app . /public
+USER app
 RUN npm run hof-transpile
 EXPOSE 8080
-CMD /app/run.sh
 
+CMD ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,4 @@ if [[ -d ${PUBLIC_DIR} ]] && [[ ! $(ls -A ${PUBLIC_DIR}) ]]; then
   cp -r /app/public/ /
 fi
 
-npm start
+exec "npm start"


### PR DESCRIPTION
In theory this should fix the running as root problem.  I haven't tested whether the /public directory will actually be mounted as USER app but it's "supposed to".  However, this is currently broken in the run.sh file anyways.