### PR TITLE
[BRP-76] Add email field to 3rd party

### DIFF
--- a/acceptance_tests/features/CollectionFormStep06Validation.feature
+++ b/acceptance_tests/features/CollectionFormStep06Validation.feature
@@ -14,3 +14,10 @@ Feature: Validation for Step 06 of the Collection Form
 		And I click Send
 		Then I see the "What is the name of the person who helped you complete this form?" link
 		And I see "What is the name of the person who helped you complete this form?"
+
+	Scenario: Attempting to proceed to Step 06 of the Delivery Form with an invalid representative email address
+		When I check the "Yes" radio button
+		And I enter a representative email address without an @
+		And I click Send
+		Then I see the "Enter the email in the correct format for example, name@domain.com" link
+		And I see "Enter the email in the correct format for example, name@domain.com"

--- a/acceptance_tests/features/step_definitions/A_Common_Reusable_Steps.rb
+++ b/acceptance_tests/features/step_definitions/A_Common_Reusable_Steps.rb
@@ -189,6 +189,10 @@ When(/^I enter an email address without an @$/) do
   fill_in('email', :with => 'btsbullerproof.cr')
 end
 
+When(/^I enter a representative email address without an @$/) do
+  fill_in('rep-email', :with => 'btsbullerproof.cr')
+end
+
 When(/^I fill the Phone number field with special characters$/) do
   fill_in('phone', :with => '^&^&^&^&')
 end

--- a/app.js
+++ b/app.js
@@ -99,7 +99,6 @@ app.get('/terms-and-conditions', function renderTerms(req, res) {
 // errors
 app.use(require('./errors/'));
 
-
 /*eslint camelcase: 0*/
 app.listen(config.port, config.listen_host);
 /*eslint camelcase: 1*/

--- a/apps/collection/steps.js
+++ b/apps/collection/steps.js
@@ -86,6 +86,7 @@ module.exports = {
     fields: [
       'org-help',
       'rep-name',
+      'rep-email',
       'org-type'
     ],
     backLink: 'contact-details',

--- a/apps/common/fields/organisation-details.js
+++ b/apps/common/fields/organisation-details.js
@@ -25,6 +25,14 @@ module.exports = {
       value: 'yes'
     },
   },
+  'rep-email': {
+    validate: ['email'],
+    label: 'fields.rep-email.label',
+    dependent: {
+      field: 'org-help',
+      value: 'yes'
+    }
+  },
   'org-type': {
     validate: ['required'],
     dependent: {

--- a/apps/common/translations/src/en/fields.json
+++ b/apps/common/translations/src/en/fields.json
@@ -1,0 +1,34 @@
+{
+  "org-help": {
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "rep-name": {
+    "label": "Full name"
+  },
+  "rep-email": {
+    "label": "E-mail"
+  },
+  "org-type": {
+    "options": {
+      "pbs": {
+        "label": "PBS sponsor"
+      },
+      "legal": {
+        "label": "Legal represntative"
+      },
+      "relative": {
+        "label": "Relative/friend"
+      },
+      "support": {
+        "label": "Support organisation"
+      }
+    }
+  }
+}

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -22,5 +22,18 @@
   },
   "contact-address-postcode": {
     "required": "Enter the postcode"
+  },
+  "org-help": {
+    "required": "Did you have help completing this form?"
+  },
+  "rep-name": {
+    "required": "What is the name of the person who helped you complete this form?"
+  },
+  "rep-email": {
+    "required": "What is the contact e-mail address of the person who helped you complete this form?",
+    "email": "Enter the email in the correct format for example, name@domain.com"
+  },
+  "org-type": {
+    "required": "Who has helped you fill in this form?"
   }
 }

--- a/apps/common/views/partials/org-type.html
+++ b/apps/common/views/partials/org-type.html
@@ -6,6 +6,7 @@
 <div id="org-details-group" class="panel-indent">
   <p>{{#t}}pages.check-details.org-details-group.header{{/t}}</p>
   {{#input-text}}rep-name{{/input-text}}
+  {{#input-text}}rep-email{{/input-text}}
   <p>{{#t}}pages.check-details.org-details-group.type{{/t}}</p>
   {{#radio-group}}org-type{{/radio-group}}
 </div>

--- a/apps/correct-mistakes/steps.js
+++ b/apps/correct-mistakes/steps.js
@@ -113,6 +113,7 @@ module.exports = {
     fields: [
       'org-help',
       'rep-name',
+      'rep-email',
       'org-type'
     ],
     backLink: 'contact-details',

--- a/apps/lost-stolen-damaged/steps.js
+++ b/apps/lost-stolen-damaged/steps.js
@@ -57,6 +57,7 @@ module.exports = {
     fields: [
       'org-help',
       'rep-name',
+      'rep-email',
       'org-type'
     ],
     backLink: 'contact-details',

--- a/apps/not-arrived/steps.js
+++ b/apps/not-arrived/steps.js
@@ -70,6 +70,7 @@ module.exports = {
     fields: [
       'org-help',
       'rep-name',
+      'rep-email',
       'org-type'
     ],
     backLink: 'contact-details',

--- a/apps/someone-else/steps.js
+++ b/apps/someone-else/steps.js
@@ -85,6 +85,7 @@ module.exports = {
     fields: [
       'org-help',
       'rep-name',
+      'rep-email',
       'org-type'
     ],
     next: '/confirmation'

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-filenames": "^0.1.1",
     "eslint-plugin-mocha": "^0.2.2",
     "eslint-plugin-one-variable-per-var": "0.0.3",
-    "hof-transpiler": "0.0.5",
+    "hof-transpiler": "0.0.6",
     "jscs": "^1.13.1",
     "mocha": "^2.2.5",
     "mocha-junit-reporter": "^1.4.0",

--- a/services/email/index.js
+++ b/services/email/index.js
@@ -109,6 +109,23 @@ Emailer.prototype.send = function send(email, callback) {
         };
       }
     };
+    var attachments = [
+      {
+        filename: 'govuk_logotype_email.png',
+        path: path.resolve(__dirname, './images/govuk_logotype_email.png'),
+        cid: 'govuk_logotype_email'
+      },
+      {
+        filename: 'ho_crest_27px.png',
+        path: path.resolve(__dirname, './images/ho_crest_27px.png'),
+        cid: 'ho_crest_27px'
+      },
+      {
+        filename: 'spacer.gif',
+        path: path.resolve(__dirname, './images/spacer.gif'),
+        cid: 'spacer_image'
+      }
+    ];
 
     function sendCustomerEmail() {
       if (email.to) {
@@ -119,23 +136,7 @@ Emailer.prototype.send = function send(email, callback) {
           subject: email.subject,
           text: Hogan.compile(customerPlainTextTemplates[email.template]).render(templateData),
           html: Hogan.compile(customerHtmlTemplates[email.template]).render(templateData),
-          attachments: [
-            {
-              filename: 'govuk_logotype_email.png',
-              path: path.resolve(__dirname, './images/govuk_logotype_email.png'),
-              cid: 'govuk_logotype_email'
-            },
-            {
-              filename: 'ho_crest_27px.png',
-              path: path.resolve(__dirname, './images/ho_crest_27px.png'),
-              cid: 'ho_crest_27px'
-            },
-            {
-              filename: 'spacer.gif',
-              path: path.resolve(__dirname, './images/spacer.gif'),
-              cid: 'spacer_image'
-            }
-          ]
+          attachments: attachments
         }, callback);
       } else {
         callback();
@@ -149,24 +150,12 @@ Emailer.prototype.send = function send(email, callback) {
       subject: email.subject,
       text: Hogan.compile(caseworkerPlainTextTemplates[email.template]).render(templateData),
       html: Hogan.compile(caseworkerHtmlTemplates[email.template]).render(templateData),
-      attachments: [
-        {
-          filename: 'govuk_logotype_email.png',
-          path: path.resolve(__dirname, './images/govuk_logotype_email.png'),
-          cid: 'govuk_logotype_email'
-        },
-        {
-          filename: 'ho_crest_27px.png',
-          path: path.resolve(__dirname, './images/ho_crest_27px.png'),
-          cid: 'ho_crest_27px'
-        },
-        {
-          filename: 'spacer.gif',
-          path: path.resolve(__dirname, './images/spacer.gif'),
-          cid: 'spacer_image'
-        }
-      ]
-    }, sendCustomerEmail.bind(this));
+      attachments: attachments
+    }, function errorHandler(err) {
+      return err
+        ? callback(err)
+        : sendCustomerEmail.bind(this)();
+    }.bind(this));
   }.bind(this));
 };
 

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -175,7 +175,8 @@
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{rep-name}}
+                            {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
+                            {{^rep-email}}{{rep-name}}{{/rep-email}}
                           </p>
                         </td>
                       </tr>

--- a/services/email/templates/caseworker/html/delivery.mus
+++ b/services/email/templates/caseworker/html/delivery.mus
@@ -95,7 +95,8 @@
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{rep-name}}
+                            {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
+                            {{^rep-email}}{{rep-name}}{{/rep-email}}
                           </p>
                         </td>
                       </tr>

--- a/services/email/templates/caseworker/html/error.mus
+++ b/services/email/templates/caseworker/html/error.mus
@@ -94,7 +94,8 @@
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{rep-name}}
+                            {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
+                            {{^rep-email}}{{rep-name}}{{/rep-email}}
                           </p>
                         </td>
                       </tr>

--- a/services/email/templates/caseworker/html/lost_or_stolen.mus
+++ b/services/email/templates/caseworker/html/lost_or_stolen.mus
@@ -95,7 +95,8 @@
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{rep-name}}
+                            {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
+                            {{^rep-email}}{{rep-name}}{{/rep-email}}
                           </p>
                         </td>
                       </tr>

--- a/services/email/templates/caseworker/html/someone-else.mus
+++ b/services/email/templates/caseworker/html/someone-else.mus
@@ -127,7 +127,8 @@
                         <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{rep-name}}
+                            {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
+                            {{^rep-email}}{{rep-name}}{{/rep-email}}
                           </p>
                         </td>
                       </tr>

--- a/services/email/templates/caseworker/plain/collection.mus
+++ b/services/email/templates/caseworker/plain/collection.mus
@@ -81,7 +81,7 @@
   {{/email}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/caseworker/plain/delivery.mus
+++ b/services/email/templates/caseworker/plain/delivery.mus
@@ -46,7 +46,7 @@
   {{/email}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/caseworker/plain/error.mus
+++ b/services/email/templates/caseworker/plain/error.mus
@@ -114,7 +114,7 @@
   {{/phone}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/caseworker/plain/lost_or_stolen.mus
+++ b/services/email/templates/caseworker/plain/lost_or_stolen.mus
@@ -46,7 +46,7 @@
   {{/email}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/caseworker/plain/someone-else.mus
+++ b/services/email/templates/caseworker/plain/someone-else.mus
@@ -55,7 +55,7 @@
   {{/contact-address-street}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/customer/plain/collection.mus
+++ b/services/email/templates/customer/plain/collection.mus
@@ -88,7 +88,7 @@
   {{/email}}
 
   {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-help}}
 
 {{/data}}

--- a/services/email/templates/customer/plain/delivery.mus
+++ b/services/email/templates/customer/plain/delivery.mus
@@ -52,7 +52,7 @@
   {{/phone}}
 
   {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-help}}
 
 {{/data}}

--- a/services/email/templates/customer/plain/error.mus
+++ b/services/email/templates/customer/plain/error.mus
@@ -123,7 +123,7 @@
   {{/phone}}
 
   {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-help}}
 
 {{/data}}

--- a/services/email/templates/customer/plain/lost_or_stolen_abroad.mus
+++ b/services/email/templates/customer/plain/lost_or_stolen_abroad.mus
@@ -34,7 +34,7 @@
   {{/phone}}
 
   {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-help}}
 
 {{/data}}

--- a/services/email/templates/customer/plain/lost_or_stolen_uk.mus
+++ b/services/email/templates/customer/plain/lost_or_stolen_uk.mus
@@ -30,7 +30,7 @@
   {{/phone}}
 
   {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-help}}
 
 {{/data}}

--- a/services/email/templates/customer/plain/someone-else.mus
+++ b/services/email/templates/customer/plain/someone-else.mus
@@ -61,7 +61,7 @@
   {{/email}}
 
   {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}}
+  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-help}}
 
 {{/data}}


### PR DESCRIPTION
This PR adds an optional e-mail field to the 3rd party and the end of each of the journeys and exposes this information in the e-mails when it is available.

It also includes a fix me prevent silent failure when sending the case-worker e-mail. (For example when the address is invalid.)

The version of hof-transpiler is also bumped.

As this PR touches many files, all journeys and the e-mails (which exist outside of our automated testing!) a code review would be appreciated.