### PR TITLE
Tidy up emails

### DIFF
--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -172,7 +172,7 @@
                     {{/email}}
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}

--- a/services/email/templates/caseworker/html/delivery.mus
+++ b/services/email/templates/caseworker/html/delivery.mus
@@ -92,7 +92,7 @@
                     {{/address-street}}
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}

--- a/services/email/templates/caseworker/html/error.mus
+++ b/services/email/templates/caseworker/html/error.mus
@@ -91,7 +91,7 @@
                     {{/address-street}}
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}

--- a/services/email/templates/caseworker/html/lost_or_stolen.mus
+++ b/services/email/templates/caseworker/html/lost_or_stolen.mus
@@ -92,7 +92,7 @@
                     {{/brp-card}}
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}

--- a/services/email/templates/caseworker/html/someone-else.mus
+++ b/services/email/templates/caseworker/html/someone-else.mus
@@ -124,7 +124,7 @@
                     {{/someone-else-reason-radio}}
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{org-type}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}

--- a/services/email/templates/caseworker/plain/collection.mus
+++ b/services/email/templates/caseworker/plain/collection.mus
@@ -81,7 +81,7 @@
   {{/email}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
+  Help from a {{#t}}fields.org-type.options[{{org-type}}].label{{/t}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/caseworker/plain/delivery.mus
+++ b/services/email/templates/caseworker/plain/delivery.mus
@@ -46,7 +46,7 @@
   {{/email}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
+  Help from a {{#t}}fields.org-type.options[{{org-type}}].label{{/t}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/caseworker/plain/error.mus
+++ b/services/email/templates/caseworker/plain/error.mus
@@ -114,7 +114,7 @@
   {{/phone}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
+  Help from a {{#t}}fields.org-type.options[{{org-type}}].label{{/t}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/caseworker/plain/someone-else.mus
+++ b/services/email/templates/caseworker/plain/someone-else.mus
@@ -55,7 +55,7 @@
   {{/contact-address-street}}
 
   {{#org-type}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
+  Help from a {{#t}}fields.org-type.options[{{org-type}}].label{{/t}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
   {{/org-type}}
 
 {{/data}}

--- a/services/email/templates/customer/plain/collection.mus
+++ b/services/email/templates/customer/plain/collection.mus
@@ -87,10 +87,6 @@
   {{email}}
   {{/email}}
 
-  {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
-  {{/org-help}}
-
 {{/data}}
 
 

--- a/services/email/templates/customer/plain/delivery.mus
+++ b/services/email/templates/customer/plain/delivery.mus
@@ -51,10 +51,6 @@
     {{phone}}
   {{/phone}}
 
-  {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
-  {{/org-help}}
-
 {{/data}}
 
 If you're unsure an email is from UKVI:

--- a/services/email/templates/customer/plain/error.mus
+++ b/services/email/templates/customer/plain/error.mus
@@ -122,10 +122,6 @@
     {{phone}}
   {{/phone}}
 
-  {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
-  {{/org-help}}
-
 {{/data}}
 
 If you're unsure an email is from UKVI:

--- a/services/email/templates/customer/plain/lost_or_stolen_abroad.mus
+++ b/services/email/templates/customer/plain/lost_or_stolen_abroad.mus
@@ -33,10 +33,6 @@
     {{phone}}
   {{/phone}}
 
-  {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
-  {{/org-help}}
-
 {{/data}}
 
 

--- a/services/email/templates/customer/plain/lost_or_stolen_uk.mus
+++ b/services/email/templates/customer/plain/lost_or_stolen_uk.mus
@@ -29,10 +29,6 @@
     {{phone}}
   {{/phone}}
 
-  {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
-  {{/org-help}}
-
 {{/data}}
 
 

--- a/services/email/templates/customer/plain/someone-else.mus
+++ b/services/email/templates/customer/plain/someone-else.mus
@@ -60,10 +60,6 @@
   {{email}}
   {{/email}}
 
-  {{#org-help}}
-  Help from a {{org-type}} called {{rep-name}} {{#rep-email}}<{{rep-email}}>{{/rep-email}}
-  {{/org-help}}
-
 {{/data}}
 
 


### PR DESCRIPTION
Expand the org-type with a translation to give a little more description in the caseworker email.

Remove some fields from customer emails that are not required.