### PR TITLE
BRP-78: No letter exit page

### DIFF
--- a/acceptance_tests/features/DeliveryFormStep01NoLetterExitPage.feature
+++ b/acceptance_tests/features/DeliveryFormStep01NoLetterExitPage.feature
@@ -1,0 +1,12 @@
+@DeliveryForm @ExitPage @StepOne @DSP-103
+Feature:  No Letter Exit Page for Step 01 of the Delivery Form
+
+  Background:
+    When I go to Step One of the delivery form
+
+  Scenario: Selecting the I don't have the letter checkbox on Step One
+    When I check the "Yes" radio button
+    And I check the "I don't have the letter" checkbox
+    And I click "Continue"
+    Then I am on the Delivery No Letter exit page
+    And I see the "Close" link

--- a/acceptance_tests/features/step_definitions/DeliveryFormStep01NoLetterExitPage.rb
+++ b/acceptance_tests/features/step_definitions/DeliveryFormStep01NoLetterExitPage.rb
@@ -1,0 +1,6 @@
+Then(/^I am on the Delivery No Letter exit page$/) do
+  page.should have_content('Contact us')
+  page.should have_content('We need to know the date on your letter so we can look into why you haven\'t received your BRP. To find out when your letter was sent, call customer services on 0300 123 2241.')
+  find_link('Close').visible?
+  delete_cookie('hmbrp.sid')
+end

--- a/acceptance_tests/features/step_definitions/DeliveryFormStep02.rb
+++ b/acceptance_tests/features/step_definitions/DeliveryFormStep02.rb
@@ -1,31 +1,18 @@
-When(/^I go to Step Two of the delivery form$/) do                                                
+When(/^I go to Step Two of the delivery form$/) do
   visit config['not_arrived_host']
   choose('received-yes')
   fill_in('delivery-date-day', :with => '17')
   fill_in('delivery-date-month', :with => '08')
   fill_in('delivery-date-year', :with => '1988')
   click_button('Continue')
-end                                                                          
-                                                                             
-Then(/^I am on Step Two of the delivery form$/) do                                         
-  page.should have_content('Step 2 of 5')
-  # page.should have_content('Is your address the same as on the Home Office letter saying your application to remain in the UK was successful?')
-  # page.should have_content('House name or number and street')
-  # find_by_id('address.street')
-  # page.should have_content('Town/City')
-  # find_by_id('address-town')
-  # page.should have_content('County')
-  # find_by_id('address-county')
-  # page.should have_content('Postcode')
-  # find_by_id('address-postcode')
-  # page.should have_content('If you think the courier may have had a problem delivering items to this address (for example there is no number on the door) then let us know and we will contact the courier.')
-  # find_by_id('delivery-details-label')
-  # page.should have_unchecked_field('Yes')
-  # page.should have_unchecked_field('No')
-  find_button('Continue').click
+end
+
+Then(/^I am on the lost letter page of the delivery form delivery form$/) do
+  page.should have_content('We need to know the date on your letter so we can look into why you haven\'t received your BRP. To find out when your letter was sent, call customer services on 0300 123 2241')
+  find_button('Close').click
   delete_cookie('hmbrp.sid')
 end
 
 Given /^I wait for (\d+) seconds?$/ do |n|
   sleep(n.to_i)
-end                                                                       
+end

--- a/apps/not-arrived/fields/letter-received.js
+++ b/apps/not-arrived/fields/letter-received.js
@@ -19,35 +19,19 @@ module.exports = {
   },
   'delivery-date': {
     legend: 'fields.delivery-date.legend',
-    hint: 'fields.dalivery-date.hint',
-    dependent: {
-      value: 'yes',
-      field: 'received',
-    }
+    hint: 'fields.dalivery-date.hint'
   },
   'delivery-date-day': {
     validate: ['required', 'numeric'],
-    label: 'fields.delivery-date-day.label',
-    dependent: {
-      value: 'yes',
-      field: 'received',
-    }
+    label: 'fields.delivery-date-day.label'
   },
   'delivery-date-month': {
     validate: ['required', 'numeric'],
-    label: 'fields.delivery-date-month.label',
-    dependent: {
-      value: 'yes',
-      field: 'received',
-    }
+    label: 'fields.delivery-date-month.label'
   },
   'delivery-date-year': {
     validate: ['required', 'numeric'],
-    label: 'fields.delivery-date-year.label',
-    dependent: {
-      value: 'yes',
-      field: 'received',
-    }
+    label: 'fields.delivery-date-year.label'
   },
   'no-letter': {
     label: 'fields.no-letter.label',

--- a/apps/not-arrived/index.js
+++ b/apps/not-arrived/index.js
@@ -20,7 +20,7 @@ router.use(mixins(fields, {
 }));
 
 router.use('/not-arrived/', wizard(require('./steps'), fields, {
-  controller: require('../../lib/base-controller'),
+  controller: require('hof').controllers.base,
   templatePath: path.resolve(__dirname, 'views'),
   translate: i18n.translate.bind(i18n),
   params: '/:action?'

--- a/apps/not-arrived/steps.js
+++ b/apps/not-arrived/steps.js
@@ -15,10 +15,23 @@ module.exports = {
       'delivery-date-year',
       'no-letter'
     ],
-    next: '/same-address'
+    next: '/same-address',
+    forks: [{
+      target: '/letter-not-received',
+      condition: {
+        field: 'received',
+        value: 'no'
+      }
+    }, {
+      target: '/letter-lost',
+      condition: {
+        field: 'no-letter',
+        value: 'true'
+      }
+    }]
   },
-  '/letter-not-received': {
-  },
+  '/letter-lost': {},
+  '/letter-not-received': {},
   '/on-the-way': {
     controller: require('./controllers/on-the-way'),
     prereqs: ['/']

--- a/apps/not-arrived/translations/src/en/pages.json
+++ b/apps/not-arrived/translations/src/en/pages.json
@@ -16,6 +16,10 @@
       "two": "Call the contact centre 0300 123 2241."
     }
   },
+  "letter-lost": {
+    "header": "Contact us",
+    "description": "We need to know the date on your letter so we can look into why you haven't received your BRP. To find out when your letter was sent, call customer services on 0300 123 2241."
+  },
   "on-the-way": {
     "header": "Your biometric residence permit should be on the way",
     "para": {

--- a/apps/not-arrived/views/letter-lost.html
+++ b/apps/not-arrived/views/letter-lost.html
@@ -1,0 +1,31 @@
+{{<layout}}
+
+  {{$journeyHeader}}
+    {{#t}}journeys.delivery.header{{/t}}
+  {{/journeyHeader}}
+
+  {{$propositionHeader}}
+    {{> partials-navigation}}
+  {{/propositionHeader}}
+
+
+  {{$title}}
+    {{#t}}pages.letter-lost.header{{/t}}
+  {{/title}}
+
+  {{$header}}
+    {{<partials-page-header}}
+      {{$page-header}}
+        {{#t}}pages.letter-lost.header{{/t}}
+      {{/page-header}}
+    {{/partials-page-header}}
+  {{/header}}
+
+  {{$content}}
+
+    <p>{{#t}}pages.letter-lost.description{{/t}}</p>
+    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+
+  {{/content}}
+
+{{/layout}}

--- a/errors/index.js
+++ b/errors/index.js
@@ -8,7 +8,7 @@ var config = require('../config');
 var logger = require('../lib/logger');
 
 /*eslint no-unused-vars: 0*/
-module.exports = function errorHandler(err, req, res, next) {
+module.exports = function errorHandler(err, req, res) {
   /*eslint no-unused-vars: 1*/
   var content = {};
 

--- a/test/unit/apps/not-arrived/controllers/letter-received.js
+++ b/test/unit/apps/not-arrived/controllers/letter-received.js
@@ -1,8 +1,19 @@
 'use strict';
 
-var Controller = require('../../../../../lib/base-controller');
-var DateController = require('../../../../../lib/date-controller');
-var LetterReceivedController = require('../../../../../apps/not-arrived/controllers/letter-received');
+var proxyquire = require('proxyquire');
+
+var DateController = function () {
+  this.options = {};
+};
+DateController.prototype.saveValues = sinon.stub();
+
+var LetterReceivedController = proxyquire('../../../../../apps/not-arrived/controllers/letter-received', {
+  'hof': {
+    controllers: {
+      date: DateController
+    }
+  }
+});
 var moment = require('moment');
 
 describe('controllers/letter-received', function () {
@@ -30,9 +41,9 @@ describe('controllers/letter-received', function () {
       should.equal(controller.validateField(key, req), undefined);
     });
 
-    it('redirects user to /letter-not-received', function () {
+    it('delegates to date controller to redirect', function () {
       controller.saveValues(req, res);
-      controller.options.next.should.equal('/letter-not-received');
+      should.equal(controller.options.next, undefined);
     });
 
   });
@@ -66,14 +77,14 @@ describe('controllers/letter-received', function () {
         DateController.prototype.validateField.should.have.been.calledWith(key, req);
       });
 
-      it('will redirect the user to the same-address page', function () {
+      it('delegates to the date controller to redirect', function () {
         controller.saveValues(req, res);
-        controller.options.next.should.equal('/same-address');
+        should.equal(controller.options.next, undefined);
       });
 
       it('calls the parent controllers\' saveValues with the arguments', function () {
         controller.saveValues(req, res, callback);
-        Controller.prototype.saveValues.should.have.been.calledWith(req, res, callback);
+        DateController.prototype.saveValues.should.have.been.calledWith(req, res, callback);
       });
 
     });


### PR DESCRIPTION
- create new exit page for users who've lost their letter
- redirect to the lost letter page when appropriate
- add accecptance test for lost letter
- update v of hof-controllers in brp
- point letter-received controller at hof-controllers
- utilise base controller fork for letter-received
- check values in letter-received validateField
- remove dependent properties from fields where not working