### PR TITLE
[BRP-117] Change heading on cancel nomination page

### DIFF
--- a/apps/someone-else/translations/src/en/pages.json
+++ b/apps/someone-else/translations/src/en/pages.json
@@ -23,7 +23,7 @@
     }
   },
   "exit-cancel-request": {
-    "header": "You cannot use this service",
+    "header": "You don't need to use this service",
     "subheader": "You do not need to cancel your request for a nominated person to collect your BRP. If you are still unable to collect your BRP yourself, you can nominate a new person to collect it for you."
   },
   "contact-details": {


### PR DESCRIPTION
"Nominate: Change heading on cancel nomination page

On this page:
https://www.biometric-residence-permit.service.gov.uk/someone-else/exit-cancel-request

Change the heading from: You cannot use this service
To : You don’t need to use this service"