### PR TITLE
[BRP-104] Add Case ID for new addresses in Delivery

### DIFF
--- a/acceptance_tests/features/DeliveryFormStep02Validation.feature
+++ b/acceptance_tests/features/DeliveryFormStep02Validation.feature
@@ -11,10 +11,11 @@ Feature: Validation for Step 02 of the Delivery Form
 
 	Scenario: Attempting to proceed to Step 03 of the Delivery Form have selecting the No radio button having not completed the address fields
 		When I check the "No" radio button
-		When I click Continue
+		And I click Continue
 		Then I see the "Enter your street" link
-		Then I see the "Enter the town or city" link
-		Then I see the "Enter the postcode" link
+		And I see the "Enter the town or city" link
+		And I see the "Enter the postcode" link
+		And I see the "A case ID number is required for your BRP to be sent to a different address" link
 
 	Scenario: Attempting to proceed to Step 03 of the Delivery Form without filling in the first address field
 		When I check the "No" radio button
@@ -40,8 +41,15 @@ Feature: Validation for Step 02 of the Delivery Form
 		Then I see the "Enter the postcode" link
 		And I see "Enter the postcode"
 
-	Scenario: Attempting to proceed to Step 03 of the Delivery Form having selected the No radio button and completing the required address fields
+	Scenario: Attempting to proceed to Step 03 of the Delivery Form without filling in the case-id field
 		When I check the "No" radio button
     And I fill in all the address details
+		When I click Continue
+		Then I see the "A case ID number is required for your BRP to be sent to a different address" link
+
+	Scenario: Attempting to proceed to Step 03 of the Delivery Form having selected the No radio button and completing the required address and case-id fields
+		When I check the "No" radio button
+    And I fill in all the address details
+    And I fill in the case-id field
 		When I click Continue
 		Then I am on Step Three of the delivery form

--- a/acceptance_tests/features/step_definitions/A_Common_Reusable_Steps.rb
+++ b/acceptance_tests/features/step_definitions/A_Common_Reusable_Steps.rb
@@ -137,6 +137,10 @@ When(/^I fill in the postcode field with special characters$/) do
   fill_in('address-postcode', :with => '!&^')
 end
 
+When(/^I fill in the case-id field$/) do
+  fill_in('case-id', :with => '1')
+end
+
 #
 # => DSP-66_.steps
 #

--- a/acceptance_tests/features/step_definitions/DeliveryFormStep03.rb
+++ b/acceptance_tests/features/step_definitions/DeliveryFormStep03.rb
@@ -10,6 +10,7 @@ When(/^I go to Step Three of the delivery form$/) do
   fill_in('address-street', :with => 'Marsham Street')
   fill_in('address-town', :with => 'Westminster')
   fill_in('address-postcode', :with => 'SW1P 4DF')
+  fill_in('case-id', :with => '1')
   click_button('Continue')
 end                                                                          
                                                                              

--- a/acceptance_tests/features/step_definitions/DeliveryFormStep04.rb
+++ b/acceptance_tests/features/step_definitions/DeliveryFormStep04.rb
@@ -10,6 +10,7 @@ When(/^I go to Step Four of the delivery form$/) do
   fill_in('address-street', :with => 'Marsham Street')
   fill_in('address-town', :with => 'Westminster')
   fill_in('address-postcode', :with => 'SW1P 4DF')
+  fill_in('case-id', :with => '1')
   click_button('Continue')
   fill_in('fullname', :with => 'Alex Murphy')
   fill_in('date-of-birth-day', :with => '17')

--- a/apps/common/translations/src/en/common-fields.json
+++ b/apps/common/translations/src/en/common-fields.json
@@ -16,5 +16,9 @@
   },
   "address-postcode": {
     "label": "Postcode"
+  },
+  "case-id": {
+    "label": "Case ID number",
+    "hint": "(Enter the case ID found on your visa decision letter.)"
   }
 }

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -11,6 +11,9 @@
   "address-postcode": {
     "required": "Enter the postcode"
   },
+  "case-id": {
+    "required": "A case ID number is required for your BRP to be sent to a different address"
+  },
   "contact-address-house-number": {
     "required": "Enter your house name or number"
   },

--- a/apps/not-arrived/fields/address-match.js
+++ b/apps/not-arrived/fields/address-match.js
@@ -61,4 +61,13 @@ module.exports = {
       field: 'address-match',
     }
   },
+  'case-id': {
+    validate: ['required'],
+    label: 'common-fields.case-id.label',
+    hint: 'common-fields.case-id.hint',
+    dependent: {
+      value: 'no',
+      field: 'address-match',
+    }
+  }
 };

--- a/apps/not-arrived/steps.js
+++ b/apps/not-arrived/steps.js
@@ -34,7 +34,8 @@ module.exports = {
   '/letter-not-received': {},
   '/on-the-way': {
     controller: require('./controllers/on-the-way'),
-    prereqs: ['/']
+    prereqs: ['/'],
+    clearSession: true
   },
   '/same-address': {
     template: 'same-address-details.html',
@@ -45,7 +46,8 @@ module.exports = {
       'address-street',
       'address-town',
       'address-county',
-      'address-postcode'
+      'address-postcode',
+      'case-id'
     ],
     backLink: 'letter-received',
     next: '/personal-details'

--- a/apps/not-arrived/views/confirm.html
+++ b/apps/not-arrived/views/confirm.html
@@ -75,6 +75,11 @@
               </td>
               <td><a href="same-address/edit#new-address-fieldset" class="button">{{#t}}buttons.change{{/t}}</a></td>
             </tr>
+            <tr>
+              <td>{{#t}}common-fields.case-id.label{{/t}}</td>
+              <td>{{values.case-id}}</td>
+              <td><a href="same-address/edit#case-id" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            </tr>
             {{/values.address-street}}
           </tbody>
         </table>

--- a/apps/not-arrived/views/same-address-details.html
+++ b/apps/not-arrived/views/same-address-details.html
@@ -63,6 +63,8 @@
 
           {{#input-text-code}}address-postcode{{/input-text-code}}
 
+          {{#input-text}}case-id{{/input-text}}
+
         </fieldset>
 
         {{#input-submit}}continue{{/input-submit}}

--- a/services/email/templates/caseworker/html/delivery.mus
+++ b/services/email/templates/caseworker/html/delivery.mus
@@ -174,6 +174,12 @@
                           </p>
                         </td>
                       </tr>
+                      <tr style="border-top: 1px solid #009390;">
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}common-fields.case-id.label{{/t}}</p></td>
+                        <td width="75%">
+                          <p style="font-size: 16px; color: #000; margin: 10px 0;">{{case-id}}</p>
+                        </td>
+                      </tr>
                     {{/address-street}}
                   </table>
 

--- a/services/email/templates/caseworker/plain/delivery.mus
+++ b/services/email/templates/caseworker/plain/delivery.mus
@@ -23,6 +23,9 @@ Personal Details
 {{address-town}},
 {{#address-county}}{{address-county}},{{/address-county}}
 {{address-postcode}}
+
+{{#t}}common-fields.case-id.label{{/t}}
+{{case-id}}
 {{/address-street}}
 
 Contact Details
@@ -65,6 +68,9 @@ Delivery Details
 {{address-town}},
 {{#address-county}}{{address-county}},{{/address-county}}
 {{address-postcode}}
+
+{{#t}}common-fields.case-id.label{{/t}}
+{{case-id}}
 {{/address-street}}
 
 {{#org-type}}

--- a/services/email/templates/customer/html/delivery.mus
+++ b/services/email/templates/customer/html/delivery.mus
@@ -99,6 +99,12 @@
                           </p>
                         </td>
                       </tr>
+                      <tr style="border-top: 1px solid #009390;">
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}common-fields.case-id.label{{/t}}</p></td>
+                        <td width="75%">
+                          <p style="font-size: 16px; color: #000; margin: 10px 0;">{{case-id}}</p>
+                        </td>
+                      </tr>
                     {{/address-street}}
                     <tr style="border-top: 1px solid #009390;">
                       <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}</p></td>

--- a/services/email/templates/customer/plain/delivery.mus
+++ b/services/email/templates/customer/plain/delivery.mus
@@ -26,6 +26,9 @@ Here is the information you have sent us:
 {{address-town}},
 {{#address-county}}{{address-county}},{{/address-county}}
 {{address-postcode}}
+
+{{#t}}common-fields.case-id.label{{/t}}
+{{case-id}}
 {{/address-street}}
 
 {{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}


### PR DESCRIPTION
"Delivery journey: Case ID for new addresses

If a user requests that their BRP is delivered to a different address to the one used in the initial application, then they MUST provide the 'case reference number' found on their decision letter from the Home Office.

USE THIS COPY:

Case ID number
(Enter the case ID found on your visa decision letter.)

[Error message:]
A case ID number is required for your BRP to be sent to a different address"

Note: This commit touches the "delivery" e-mails and so they should be checked manually prior to merging.