### PR TITLE
Remove the need for i18n-lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.11.3",
-    "hof": "1.2.0",
+    "hof": "2.0.0",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",
     "jquery": "^2.1.4",

--- a/services/email/index.js
+++ b/services/email/index.js
@@ -5,7 +5,6 @@ var nodemailer = require('nodemailer');
 var config = require('../../config');
 var i18n = require('hof').i18n;
 var Hogan = require('hogan.js');
-var i18nLookup = require('hof').i18nLookup;
 var fs = require('fs');
 var path = require('path');
 
@@ -99,13 +98,12 @@ Emailer.prototype.send = function send(email, callback) {
   });
 
   locali18n.on('ready', function locali18nLoaded() {
-    var lookup = i18nLookup(locali18n.translate.bind(locali18n));
     var templateData = {
       data: email.dataToSend,
       t: function t() {
         return function lookupTranslation(translate) {
           // for translations inside our mustache templates
-          return lookup(Hogan.compile(translate).render(email.dataToSend));
+          return locali18n.translate(Hogan.compile(translate).render(email.dataToSend));
         };
       }
     };


### PR DESCRIPTION
This is not really needed in the email service and it's being deprecated from hof.

Version bump hof to 2.0.0