### PR TITLE
[BRP-122] Correct nominee DOB in email

### DIFF
--- a/apps/someone-else/controllers/arrange.js
+++ b/apps/someone-else/controllers/arrange.js
@@ -22,13 +22,13 @@ ArrangeController.prototype.processDate = function processDate(key, values) {
     var month = v[k + '-month'];
     var day = v[k + '-day'];
 
-    return (year !== '' && month !== '' && day !== '') ? year + '-' + pad(month) + '-' + pad(day) : undefined;
+    return (year !== '' && month !== '' && day !== '') ? year + '-' + pad(month) + '-' + pad(day) : '';
   };
 
   var date = pureProcessDate(key, values);
 
   values[key] = date;
-  values[key + '-formatted'] = moment(date).format(prettyDate);
+  values[key + '-formatted'] = date === '' ? '' : moment(date).format(prettyDate);
 };
 
 ArrangeController.prototype.process = function process(req) {


### PR DESCRIPTION
Displays the correct nominee DOB in the email for the "someone-else"
journey, by preventing the data being over written with junk.

"Wrong nominee DOB in "Someone else" journey e-mail

When selecting "Nominate someone else to collect my BRP" on step one of
the "someone else" journey the DOB you enter for the nominee will be
replaced, in both the customer and case-worker e-mails, with today's
date.

This is probably important as presumably this information is is used to
verify the nominee's date of birth when they come to collect they
BRP."