### PR TITLE
Fix memory leak.

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,22 +65,19 @@ function secureCookies(req, res, next) {
   };
   next();
 }
-function initSession(req, res, next) {
-  session({
-    store: redisStore,
-    cookie: {
-      secure: (req.protocol === 'https')
-    },
-    key: 'hmbrp.sid',
-    secret: config.session.secret,
-    resave: true,
-    saveUninitialized: true
-  })(req, res, next);
-}
 
 app.use(require('cookie-parser')(config.session.secret));
 app.use(secureCookies);
-app.use(initSession);
+app.use(session({
+  store: redisStore,
+  cookie: {
+    secure: (config.env === 'development' || config.env === 'ci') ? false : true
+  },
+  key: 'hmbrp.sid',
+  secret: config.session.secret,
+  resave: true,
+  saveUninitialized: true
+}));
 
 // apps
 app.use(require('./apps/correct-mistakes/'));


### PR DESCRIPTION
The previous implementation was creating a new session store PER request!
This creates one store for the middleware.
The downside to this is we have to check for the dev env variable to serve sessions over HTTP as we otherwise enforse HTTPS.

_How I found the problem_:
Using wrk2 running `wrk2 -R 50000 -d 5m -t 4 -c 300 http://localhost:8080/someone-else`

Which is essentially hitting the server hard for 5minutes

Responded with
```
Running 5m test @ http://localhost:8080/someone-else
  4 threads and 300 connections
  Thread calibration: mean lat.: 4834.408ms, rate sampling interval: 16752ms
  Thread calibration: mean lat.: 4969.476ms, rate sampling interval: 18120ms
  Thread calibration: mean lat.: 4837.455ms, rate sampling interval: 16752ms
  Thread calibration: mean lat.: 4970.285ms, rate sampling interval: 18120ms
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.52m     1.37m    4.88m    57.60%
    Req/Sec   293.22      6.83   306.00     71.88%
  351077 requests in 5.00m, 143.78MB read
  Socket errors: connect 0, read 40, write 1, timeout 0
Requests/sec:   1169.87
Transfer/sec:    490.60KB
```

And at the end of the wrk the memory was at :fire::fire::fire::fire: `725.2MB` :fire::fire::fire::fire:

After this change
```
Running 5m test @ http://localhost:8080/someone-else
  4 threads and 300 connections
  Thread calibration: mean lat.: 5164.922ms, rate sampling interval: 18022ms
  Thread calibration: mean lat.: 5162.324ms, rate sampling interval: 18022ms
  Thread calibration: mean lat.: 4961.698ms, rate sampling interval: 16670ms
  Thread calibration: mean lat.: 5164.952ms, rate sampling interval: 18022ms
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.53m     1.35m    4.88m    58.32%
    Req/Sec   277.45     14.16   292.00     81.54%
  333375 requests in 5.00m, 136.53MB read
Requests/sec:   1110.41
Transfer/sec:    465.68KB
```

And at the end of the wrk the memory remained stable at :dancer::dancer::dancer::dancer: `162.4MB` :dancer::dancer::dancer::dancer:

Kubernetes will restart a pod when it hits `400MB` of memory so this would explain why we were experiencing restarts.