### PR TITLE
Proof of concept: Eliminate Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,6 @@ app:
   volumes:
   - "/public"
   net: "host"
-redis:
-  image: redis
-  net: "host"
 maildev:
   image: djfarrelly/maildev
   net: "host"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "body-parser": "^1.13.0",
     "browserify": "^12.0.1",
     "churchill": "0.0.5",
+    "client-sessions": "^0.7.0",
     "connect-redis-crypto": "^2.1.0",
     "cookie-parser": "^1.3.5",
     "express": "^4.12.4",


### PR DESCRIPTION
This is a proof of concept PR showing how Redis could be eliminated in favour of storing the session client-side, in a cookie.

At the moment, **I don't think this should be merged** as there are some serious downsides to this approach. The main one, to my mind, is the possibility of race conditions when trying to update the session in more than one way at the same time. (Imagine using AJAX to update the session, which I think HOF should support in the future, and these race conditions would be more likely.)