### PR TITLE
Updated docker-compose so all emails reach maildev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ app:
   - EMAIL_IGNORE_TLS=true
   - CASEWORKER_SOMEONEELSE_EMAIL=a@user.com
   - CASEWORKER_LOSTSTOLEN_EMAIL=a@user.com
+  - CASEWORKER_ERROR_EMAIL=a@user.com
+  - CASEWORKER_DELIVERY_EMAIL=a@user.com
+  - CASEWORKER_COLLECTION_EMAIL=a@user.com
   ports:
   - "8080:8080"
   volumes:


### PR DESCRIPTION
In order to test emails they need to be sent to valid email addresses. Docker compose now sets these email addresses for all journeys to be valid, so they can be picked up by maildev and checked