### PR TITLE
Ensure that all exit pages to go surveys.

### DIFF
--- a/apps/correct-mistakes/views/conditions-and-length.html
+++ b/apps/correct-mistakes/views/conditions-and-length.html
@@ -24,7 +24,7 @@
 
     <p>{{#t}}pages.conditions-and-length.para.one{{/t}}</p>
 
-    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+    <a class="button" href='https://www.gov.uk/done/brp-report-problem'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 

--- a/apps/correct-mistakes/views/enrolment-letter.html
+++ b/apps/correct-mistakes/views/enrolment-letter.html
@@ -24,7 +24,7 @@
 
     <p>{{#t}}pages.enrolment-letter.para.one{{/t}}</p>
 
-    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+    <a class="button" href='https://www.gov.uk/done/brp-report-problem'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 

--- a/apps/correct-mistakes/views/exit-truncated.html
+++ b/apps/correct-mistakes/views/exit-truncated.html
@@ -11,7 +11,7 @@
   {{$title}}
     {{#t}}pages.truncated.header{{/t}}
   {{/title}}
-  
+
   {{$header}}
     {{<partials-page-header}}
       {{$page-header}}
@@ -28,7 +28,7 @@
 
     <p>{{#t}}pages.exit-truncated.paras.three{{/t}}</p>
 
-    <a href='{{baseUrl}}' class='button'>{{#t}}buttons.close{{/t}}</a>
+    <a href='https://www.gov.uk/done/brp-report-problem' class='button'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 

--- a/apps/not-arrived/views/letter-lost.html
+++ b/apps/not-arrived/views/letter-lost.html
@@ -25,7 +25,7 @@
 
     <p>{{#t}}pages.letter-lost.para.one{{/t}}</p>
     <p>{{#t}}pages.letter-lost.para.two{{/t}}</p>
-    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+    <a class="button" href='https://www.gov.uk/done/brp-not-arrived'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 

--- a/apps/not-arrived/views/letter-not-received.html
+++ b/apps/not-arrived/views/letter-not-received.html
@@ -25,7 +25,7 @@
 
     <p>{{#t}}pages.letter-not-received.para.one{{/t}}</p>
     <p>{{#t}}pages.letter-not-received.para.two{{/t}}</p>
-    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+    <a class="button" href='https://www.gov.uk/done/brp-not-arrived'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 

--- a/apps/not-arrived/views/on-the-way.html
+++ b/apps/not-arrived/views/on-the-way.html
@@ -24,7 +24,7 @@
 
     <p>{{#t}}pages.on-the-way.para.one.first{{/t}}{{weekDayRange.weekDaysSince}}{{#t}}pages.on-the-way.para.one.second{{/t}}</p>
     <p>{{#t}}pages.on-the-way.para.two.first{{/t}}{{weekDayRange.weekDaysUntil}}{{#t}}pages.on-the-way.para.two.second{{/t}}</p>
-    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+    <a class="button" href='https://www.gov.uk/done/brp-not-arrived'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 

--- a/apps/someone-else/views/exit-cancel-request.html
+++ b/apps/someone-else/views/exit-cancel-request.html
@@ -24,7 +24,7 @@
 
     <p>{{#t}}pages.exit-cancel-request.subheader{{/t}}</p>
 
-    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+    <a class="button" href='https://www.gov.uk/done/someone-else-collect-brp'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 

--- a/apps/someone-else/views/exit-not-eligible.html
+++ b/apps/someone-else/views/exit-not-eligible.html
@@ -29,7 +29,7 @@
       <li>{{#t}}pages.exit-not-eligible.list.two{{/t}}</li>
     </ul>
 
-    <a class="button" href='{{baseUrl}}'>{{#t}}buttons.close{{/t}}</a>
+    <a class="button" href='https://www.gov.uk/done/someone-else-collect-brp'>{{#t}}buttons.close{{/t}}</a>
 
   {{/content}}
 


### PR DESCRIPTION
We were restarting forms instead of pushing them off to site surveys.