### PR TITLE
Bugfix/secure cookies in production

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,9 @@ app.use(function setBaseUrl(req, res, next) {
   next();
 });
 
+// Trust proxy for secure cookies
+app.set('trust proxy', 1);
+
 /*************************************/
 /******* Redis session storage *******/
 /*************************************/

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.11.3",
-    "hof": "2.0.0",
+    "hof": "3.0.0",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",
     "jquery": "^2.1.4",


### PR DESCRIPTION
So this was quite a gotcha! In local dev we don't run secure cookies. In actual dev we do but it's via a self signed certificate which was making express say :-1:

Setting a trust on the proxy sorts it out. And now I'm done it's time to:

![](https://media.giphy.com/media/YTbZzCkRQCEJa/giphy.gif)