### PR TITLE
Fixed broken aria reference to hint on form

### DIFF
--- a/apps/collection/views/where.html
+++ b/apps/collection/views/where.html
@@ -47,7 +47,7 @@
 
           <div class="form-group form-date">
             <p>{{#t}}pages.where.date-question{{/t}}</p>
-            <p class="form-hint">{{#t}}fields.collection-date.hint{{/t}}</p>
+            <p id="collection-date-hint" class="form-hint">{{#t}}fields.collection-date.hint{{/t}}</p>
             {{#input-date}}collection-date{{/input-date}}
           </div>
 


### PR DESCRIPTION
Collection date form elements had an aria-describedby attribute pointing to
the form-hint above. Added the matching id to the form hint.