### PR TITLE
Remove potential empty heading

### DIFF
--- a/apps/collection/views/confirm.html
+++ b/apps/collection/views/confirm.html
@@ -118,8 +118,8 @@
           </tr>
         </tbody>
       </table>
-      <h1>{{values.nominated-fullname}}</h1>
       {{#values.nominated-fullname}}
+        <h1>{{values.nominated-fullname}}</h1>
         <table id="others-details" class="table-details">
           <thead>
             <tr>


### PR DESCRIPTION
If there isn't a nominated person, the confirmation page shows an empty h1,
which could potentially be confusing for people relying on screen readers.

On top of that, it could be good to re-evaluate the heading structure of the
page again. It seems to jump between h1 and h3, and could be useful to
re-arrange them as h1-h2-h3 or just use h2's but add h3 classes to them
for visual purposes.