### PR TITLE
Remove testing of forking (by accident)

### DIFF
--- a/acceptance_tests/features/CollectionFormStep05ChangeDetails.feature
+++ b/acceptance_tests/features/CollectionFormStep05ChangeDetails.feature
@@ -22,7 +22,6 @@ Feature: Changing Delivery Form details
 		Examples:
 			|another reason radio button |fields 				    |another collection value|another reason    													|
 			|reason-radio-non-identity	 |reason-non-identity	    |1234					 |I could not prove my identity 									|
-			|reason-radio-others-identity|reason-others-identity    |5678					 |Someone attempted to collect my BRP on my behalf, but was unable to|
 			|reason-radio-passport-family|reason-passport-family    |3131					 |The vignette (sticker) in my passport is not linked to my family 				|
 			|reason-radio-passport-lost  |reason-passport-lost      |8989					 |I have lost my passport 												|
 


### PR DESCRIPTION
This test was testing forking as a side effect (which was broken)

It should only test returning to the confirm page which it now does.

Forking is a different set of testing issues that can't be tested using this technique.