### PR TITLE
Add hidden content on confirm pages to make it easier to navigate with a screen reader

### DIFF
--- a/apps/collection/translations/src/en/buttons.json
+++ b/apps/collection/translations/src/en/buttons.json
@@ -1,0 +1,17 @@
+{
+  "change": {
+    "attempted-location": "Change <span class=\"visuallyhidden\">attempted collection location</span>",
+    "reason": "Change <span class=\"visuallyhidden\">reason</span>",
+    "nominated-full-name": "Change <span class=\"visuallyhidden\">nominated full name</span>",
+    "nominated-dob": "Change <span class=\"visuallyhidden\">nominated date of birth</span>",
+    "nominated-nationality": "Change <span class=\"visuallyhidden\">nominated nationality</span>",
+    "nominated-id-number": "Change <span class=\"visuallyhidden\">nominated id number</span>",
+    "fullname": "Change <span class=\"visuallyhidden\">full name</span>",
+    "date-of-birth": "Change <span class=\"visuallyhidden\">date of birth</span>",
+    "nationality": "Change <span class=\"visuallyhidden\">nationality</span>",
+    "address": "Change <span class=\"visuallyhidden\">address</span>",
+    "passport": "Change <span class=\"visuallyhidden\">passport</span>",
+    "email": "Change <span class=\"visuallyhidden\">email</span>",
+    "phone": "Change <span class=\"visuallyhidden\">phone</span>"
+  }
+}

--- a/apps/collection/views/confirm.html
+++ b/apps/collection/views/confirm.html
@@ -38,7 +38,7 @@
             <tr>
               <td>{{#t}}journeys.collection.pages.check-details.tables.problem-details.where-radio.label{{/t}}</td>
               <td>{{values.collection-where-radio}}{{#values.collection-date}}<br /><span>{{values.collection-date-formatted}}</span>{{/values.collection-date}}</td>
-              <td><a href="/collection/where/edit#collection-where-radio-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/collection/where/edit#collection-where-radio-group" class="button">{{#t}}buttons.change.attempted-location{{/t}}</a></td>
             </tr>
 
             <tr>
@@ -110,7 +110,7 @@
                   {{/values.reason-other}}
                 </span>
               </td>
-              <td><a href="/collection/reasons/edit" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/collection/reasons/edit" class="button">{{#t}}buttons.change.reason{{/t}}</a></td>
             </tr>
           </tbody>
         </table>
@@ -123,28 +123,28 @@
             <tr>
               <td>{{#t}}journeys.collection.pages.check-details.tables.others-details.fullname{{/t}}</td>
               <td>{{values.nominated-fullname}}</td>
-              <td><a href="nominated-person/edit#nominated-fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="nominated-person/edit#nominated-fullname" class="button">{{#t}}buttons.change.nominated-full-name{{/t}}</a></td>
             </tr>
             {{/values.nominated-fullname}}
             {{#values.nominated-date}}
             <tr>
               <td>{{#t}}journeys.collection.pages.check-details.tables.others-details.date-of-birth{{/t}}</td>
               <td>{{values.nominated-date-formatted}}</td>
-              <td><a href="nominated-person/edit#nominated-date-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="nominated-person/edit#nominated-date-day" class="button">{{#t}}buttons.change.nominated-dob{{/t}}</a></td>
             </tr>
             {{/values.nominated-date}}
             {{#values.nominated-nationality}}
             <tr>
               <td>{{#t}}journeys.collection.pages.check-details.tables.others-details.nationality{{/t}}</td>
               <td>{{values.nominated-nationality}}</td>
-              <td><a href="nominated-person/edit#nominated-nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="nominated-person/edit#nominated-nationality" class="button">{{#t}}buttons.change.nominated-nationality{{/t}}</a></td>
             </tr>
             {{/values.nominated-nationality}}
             {{#values.nominated-id-number}}
             <tr>
               <td>{{#t}}journeys.collection.pages.check-details.tables.others-details.id-number{{/t}}</td>
               <td>{{values.nominated-id-number}}</td>
-              <td><a href="nominated-person/edit#nominated-id-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="nominated-person/edit#nominated-id-number" class="button">{{#t}}buttons.change.nominated-id-number{{/t}}</a></td>
             </tr>
             {{/values.nominated-id-number}}
           </tbody>
@@ -158,21 +158,21 @@
           <tr>
             <td>{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}</td>
             <td>{{values.fullname}}</td>
-            <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change.fullname{{/t}}</a></td>
           </tr>
           {{/values.fullname}}
           {{#values.date-of-birth}}
           <tr>
             <td>{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}</td>
             <td>{{values.date-of-birth-formatted}}</td>
-            <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change.date-of-birth{{/t}}</a></td>
           </tr>
           {{/values.date-of-birth}}
           {{#values.nationality}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.nationality{{/t}}</td>
             <td>{{values.nationality}}</td>
-            <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
           </tr>
           {{/values.nationality}}
           {{#values.no-email}}
@@ -185,7 +185,7 @@
                 {{#values.contact-address-county}}{{values.contact-address-county}},{{/values.contact-address-county}}
                 {{values.contact-address-postcode}}
               </td>
-              <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
             </tr>
           {{/values.contact-address-street}}
           {{/values.no-email}}
@@ -193,21 +193,21 @@
           <tr>
             <td>{{#t}}pages.check-details.table.headers.passport{{/t}}</td>
             <td>{{values.passport}}</td>
-            <td><a href="personal-details/edit#passport" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#passport" class="button">{{#t}}buttons.change.passport{{/t}}</a></td>
           </tr>
           {{/values.passport}}
           {{#values.email}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.email{{/t}}</td>
             <td>{{values.email}}</td>
-            <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change.email{{/t}}</a></td>
           </tr>
           {{/values.email}}
           {{#values.phone}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.phone{{/t}}</td>
               <td>{{values.phone}}</td>
-              <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change.phone{{/t}}</a></td>
             </tr>
           {{/values.phone}}
         </tbody>

--- a/apps/common/translations/src/en/buttons.json
+++ b/apps/common/translations/src/en/buttons.json
@@ -1,6 +1,5 @@
 {
   "continue": "Continue",
   "send": "Send",
-  "change": "Change",
   "close": "Close"
 }

--- a/apps/correct-mistakes/translations/src/en/buttons.json
+++ b/apps/correct-mistakes/translations/src/en/buttons.json
@@ -1,0 +1,26 @@
+{
+  "change": {
+    "first-name-error": "Change <span class=\"visuallyhidden\">corrected first name</span>",
+    "last-name-error": "Change <span class=\"visuallyhidden\">corrected last name</span>",
+    "birth-place-error": "Change <span class=\"visuallyhidden\">corrected birth place</span>",
+    "date-of-birth-error": "Change <span class=\"visuallyhidden\">corrected date of birth</span>",
+    "gender-error": "Change <span class=\"visuallyhidden\">corrected gender</span>",
+    "sponser-details-error": "Change <span class=\"visuallyhidden\">corrected sponser details</span>",
+    "nationality-error": "Change <span class=\"visuallyhidden\">corrected nationality</span>",
+    "signature-error": "Change <span class=\"visuallyhidden\">corrected signature</span>",
+    "photograph-error": "Change <span class=\"visuallyhidden\">corrected photograph</span>",
+    "national-insurance-error": "Change <span class=\"visuallyhidden\">corrected national insurance</span>",
+    "damaged-error": "Change <span class=\"visuallyhidden\">corrected damaged</span>",
+    "conditions-error": "Change <span class=\"visuallyhidden\">corrected conditions</span>",
+    "letter-error": "Change <span class=\"visuallyhidden\">corrected letter</span>",
+    "same-address": "Change <span class=\"visuallyhidden\">same address</span>",
+    "uk-address": "Change <span class=\"visuallyhidden\">uk address</span>",
+    "fullname": "Change <span class=\"visuallyhidden\">full name</span>",
+    "date-of-birth": "Change <span class=\"visuallyhidden\">date of birth</span>",
+    "nationality": "Change <span class=\"visuallyhidden\">nationality</span>",
+    "address": "Change <span class=\"visuallyhidden\">address</span>",
+    "brp-card": "Change <span class=\"visuallyhidden\">brp card</span>",
+    "email": "Change <span class=\"visuallyhidden\">email</span>",
+    "phone": "Change <span class=\"visuallyhidden\">phone</span>"
+  }
+}

--- a/apps/correct-mistakes/views/confirm.html
+++ b/apps/correct-mistakes/views/confirm.html
@@ -41,7 +41,7 @@
             <td>
               {{values.first-name-error}}
             </td>
-            <td><a href="about-error/edit#first-name-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#first-name-error" class="button">{{#t}}buttons.change.first-name-error{{/t}}</a></td>
           </tr>
         {{/values.first-name-error}}
 
@@ -51,7 +51,7 @@
             <td>
               {{values.last-name-error}}
             </td>
-            <td><a href="about-error/edit#last-name-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#last-name-error" class="button">{{#t}}buttons.change.last-name-error{{/t}}</a></td>
           </tr>
         {{/values.last-name-error}}
 
@@ -61,7 +61,7 @@
             <td>
               {{values.birth-place-error}}
             </td>
-            <td><a href="about-error/edit#birth-place-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#birth-place-error" class="button">{{#t}}buttons.change.birth-place-error{{/t}}</a></td>
           </tr>
         {{/values.birth-place-error}}
 
@@ -71,7 +71,7 @@
             <td>
               {{values.date-of-birth-error-formatted}}
             </td>
-            <td><a href="about-error/edit#date-of-birth-error-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#date-of-birth-error-group" class="button">{{#t}}buttons.change.date-of-birth-error{{/t}}</a></td>
           </tr>
         {{/values.date-of-birth-error-day}}
 
@@ -81,7 +81,7 @@
             <td>
               {{values.gender-error}}
             </td>
-            <td><a href="about-error/edit#gender-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#gender-error" class="button">{{#t}}buttons.change.gender-error{{/t}}</a></td>
           </tr>
         {{/values.gender-error}}
 
@@ -91,7 +91,7 @@
             <td>
               {{values.sponsor-details-error}}
             </td>
-            <td><a href="about-error/edit#sponsor-details-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#sponsor-details-error" class="button">{{#t}}buttons.change.sponser-details-error{{/t}}</a></td>
           </tr>
         {{/values.sponsor-details-error}}
 
@@ -101,7 +101,7 @@
             <td>
               {{values.nationality-error}}
             </td>
-            <td><a href="about-error/edit#nationality-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#nationality-error" class="button">{{#t}}buttons.change.nationality-error{{/t}}</a></td>
           </tr>
         {{/values.nationality-error}}
 
@@ -111,7 +111,7 @@
             <td>
               {{values.signature-error}}
             </td>
-            <td><a href="about-error/edit#signature-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#signature-error" class="button">{{#t}}buttons.change.signature-error{{/t}}</a></td>
           </tr>
         {{/values.signature-error}}
 
@@ -121,7 +121,7 @@
             <td>
               {{values.photograph-error}}
             </td>
-            <td><a href="about-error/edit#photograph-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#photograph-error" class="button">{{#t}}buttons.change.photograph-error{{/t}}</a></td>
           </tr>
         {{/values.photograph-error}}
 
@@ -131,7 +131,7 @@
             <td>
               {{values.national-insurance-error}}
             </td>
-            <td><a href="about-error/edit#national-insurance-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#national-insurance-error" class="button">{{#t}}buttons.change.national-insurance-error{{/t}}</a></td>
           </tr>
         {{/values.national-insurance-error}}
 
@@ -141,7 +141,7 @@
             <td>
               {{values.damaged-error}}
             </td>
-            <td><a href="about-error/edit#damaged-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#damaged-error" class="button">{{#t}}buttons.change.damaged-error{{/t}}</a></td>
           </tr>
         {{/values.damaged-error}}
 
@@ -151,7 +151,7 @@
             <td>
               {{values.conditions-error}}
             </td>
-            <td><a href="about-error/edit#conditions-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#conditions-error" class="button">{{#t}}buttons.change.conditions-error{{/t}}</a></td>
           </tr>
         {{/values.conditions-error}}
 
@@ -161,7 +161,7 @@
             <td>
               {{values.letter-error}}
             </td>
-            <td><a href="about-error/edit#letter-error" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="about-error/edit#letter-error" class="button">{{#t}}buttons.change.letter-error{{/t}}</a></td>
           </tr>
         {{/values.letter-error}}
         </tbody>
@@ -178,7 +178,7 @@
               {{#values.same-address-county}}{{values.same-address-county}},{{/values.same-address-county}}
               {{values.same-address-postcode}}
             </td>
-            <td><a href="same-address/edit#same-address-fieldset" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="same-address/edit#same-address-fieldset" class="button">{{#t}}buttons.change.same-address{{/t}}</a></td>
           </tr>
         </tbody>
       </table>
@@ -196,7 +196,7 @@
               {{#values.uk-address-county}}{{values.uk-address-county}},{{/values.uk-address-county}}
               {{values.uk-address-postcode}}
             </td>
-            <td><a href="uk-address/edit#uk-address-fieldset" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="uk-address/edit#uk-address-fieldset" class="button">{{#t}}buttons.change.uk-address{{/t}}</a></td>
           </tr>
         </tbody>
       </table>
@@ -208,21 +208,21 @@
         <tr>
           <td>{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}</td>
           <td>{{values.fullname}}</td>
-          <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+          <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change.fullname{{/t}}</a></td>
         </tr>
         {{/values.fullname}}
         {{#values.date-of-birth}}
         <tr>
           <td>{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}</td>
           <td>{{values.date-of-birth-formatted}}</td>
-          <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+          <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change.date-of-birth{{/t}}</a></td>
         </tr>
         {{/values.date-of-birth}}
         {{#values.nationality}}
         <tr>
           <td>{{#t}}pages.check-details-error.personal-details-table.headers.nationality{{/t}}</td>
           <td>{{values.nationality}}</td>
-          <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+          <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
         </tr>
         {{/values.nationality}}
 
@@ -235,7 +235,7 @@
             {{#values.contact-address-county}}{{values.contact-address-county}},{{/values.contact-address-county}}
             {{values.contact-address-postcode}}
           </td>
-          <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+          <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
         </tr>
         {{/values.contact-address-street}}
 
@@ -243,21 +243,21 @@
         <tr>
           <td>{{#t}}pages.check-details-error.personal-details-table.headers.brp-card-number{{/t}}</td>
           <td>{{values.brp-card}}</td>
-          <td><a href="personal-details/edit#brp-card" class="button">{{#t}}buttons.change{{/t}}</a></td>
+          <td><a href="personal-details/edit#brp-card" class="button">{{#t}}buttons.change.brp-card{{/t}}</a></td>
         </tr>
         {{/values.brp-card}}
         {{#values.email}}
         <tr>
           <td>{{#t}}pages.check-details-error.personal-details-table.headers.email{{/t}}</td>
           <td>{{values.email}}</td>
-          <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change{{/t}}</a></td>
+          <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change.email{{/t}}</a></td>
         </tr>
         {{/values.email}}
         {{#values.phone}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.phone{{/t}}</td>
             <td>{{values.phone}}</td>
-            <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change.phone{{/t}}</a></td>
           </tr>
         {{/values.phone}}
         </tbody>

--- a/apps/lost-stolen-damaged/translations/src/en/buttons.json
+++ b/apps/lost-stolen-damaged/translations/src/en/buttons.json
@@ -1,0 +1,11 @@
+{
+  "change": {
+    "fullname": "Change <span class=\"visuallyhidden\">full name</span>",
+    "date-of-birth": "Change <span class=\"visuallyhidden\">date of birth</span>",
+    "nationality": "Change <span class=\"visuallyhidden\">nationality</span>",
+    "address": "Change <span class=\"visuallyhidden\">address</span>",
+    "brp-card": "Change <span class=\"visuallyhidden\">brp card</span>",
+    "email": "Change <span class=\"visuallyhidden\">email</span>",
+    "phone": "Change <span class=\"visuallyhidden\">phone</span>"
+  }
+}

--- a/apps/lost-stolen-damaged/views/confirm.html
+++ b/apps/lost-stolen-damaged/views/confirm.html
@@ -36,17 +36,17 @@
           <tr>
             <td>{{#t}}pages.check-details.table.headers.fullname{{/t}}</td>
             <td>{{values.fullname}}</td>
-            <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change.fullname{{/t}}</a></td>
           </tr>
           <tr>
             <td>{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</td>
             <td>{{values.date-of-birth-formatted}}</td>
-            <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change.date-of-birth{{/t}}</a></td>
           </tr>
           <tr>
             <td>{{#t}}pages.check-details.table.headers.nationality{{/t}}</td>
             <td>{{values.nationality}}</td>
-            <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
           </tr>
           {{#values.no-email}}
           {{#values.contact-address-street}}
@@ -58,7 +58,7 @@
                 {{#values.contact-address-county}}{{values.contact-address-county}},{{/values.contact-address-county}}
                 {{values.contact-address-postcode}}
               </td>
-              <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
             </tr>
           {{/values.contact-address-street}}
           {{/values.no-email}}
@@ -66,21 +66,21 @@
             <tr>
               <td>{{#t}}pages.check-details.table.headers.brp-card-number{{/t}}</td>
               <td>{{values.brp-card}}</td>
-              <td><a href="personal-details/edit#brp-card" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="personal-details/edit#brp-card" class="button">{{#t}}buttons.change.brp-card{{/t}}</a></td>
             </tr>
           {{/values.brp-card}}
           {{#values.email}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.email{{/t}}</td>
               <td>{{values.email}}</td>
-              <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change.email{{/t}}</a></td>
             </tr>
           {{/values.email}}
           {{#values.phone}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.phone{{/t}}</td>
               <td>{{values.phone}}</td>
-              <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change.phone{{/t}}</a></td>
             </tr>
           {{/values.phone}}
         </table>

--- a/apps/not-arrived/translations/src/en/buttons.json
+++ b/apps/not-arrived/translations/src/en/buttons.json
@@ -1,0 +1,16 @@
+{
+  "change": {
+    "delivery-date": "Change <span class=\"visuallyhidden\">delivery date</span>",
+    "no-letter": "Change <span class=\"visuallyhidden\">no letter</span>",
+    "delivery-details": "Change <span class=\"visuallyhidden\">delivery details</span>",
+    "new-address": "Change <span class=\"visuallyhidden\">new address</span>",
+    "case-id": "Change <span class=\"visuallyhidden\">case id</span>",
+    "fullname": "Change <span class=\"visuallyhidden\">full name</span>",
+    "date-of-birth": "Change <span class=\"visuallyhidden\">date of birth</span>",
+    "nationality": "Change <span class=\"visuallyhidden\">nationality</span>",
+    "address": "Change <span class=\"visuallyhidden\">address</span>",
+    "passport": "Change <span class=\"visuallyhidden\">passport</span>",
+    "email": "Change <span class=\"visuallyhidden\">email</span>",
+    "phone": "Change <span class=\"visuallyhidden\">phone</span>"
+  }
+}

--- a/apps/not-arrived/views/confirm.html
+++ b/apps/not-arrived/views/confirm.html
@@ -39,14 +39,14 @@
             <tr>
               <td>{{#t}}pages.check-details.table.headers.delivery-date{{/t}}</td>
               <td>{{values.delivery-date-formatted}}</td>
-              <td><a href="letter-received/edit#delivery-date-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="letter-received/edit#delivery-date-day" class="button">{{#t}}buttons.change.delivery-date{{/t}}</a></td>
             </tr>
             {{/values.no-letter}}
 
             {{#values.no-letter}}
             <tr>
               <td colspan="2">{{#t}}pages.check-details.table.headers.no-letter{{/t}}</td>
-              <td><a href="letter-received/edit#no-letter" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="letter-received/edit#no-letter" class="button">{{#t}}buttons.change.no-letter{{/t}}</a></td>
             </tr>
             {{/values.no-letter}}
 
@@ -55,7 +55,7 @@
             <tr>
               <td>{{#t}}pages.check-details.table.headers.delivery-details{{/t}}</td>
               <td>{{values.delivery-details}}</td>
-              <td><a href="same-address/edit#delivery-details" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="same-address/edit#delivery-details" class="button">{{#t}}buttons.change.delivery-details{{/t}}</a></td>
             </tr>
             {{/values.delivery-details}}
             {{/values.address-street}}
@@ -69,12 +69,12 @@
                 {{#values.address-county}}{{values.address-county}},{{/values.address-county}}
                 {{values.address-postcode}}
               </td>
-              <td><a href="same-address/edit#new-address-fieldset" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="same-address/edit#new-address-fieldset" class="button">{{#t}}buttons.change.new-address{{/t}}</a></td>
             </tr>
             <tr>
               <td>{{#t}}common-fields.case-id.label{{/t}}</td>
               <td>{{values.case-id}}</td>
-              <td><a href="same-address/edit#case-id" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="same-address/edit#case-id" class="button">{{#t}}buttons.change.case-id{{/t}}</a></td>
             </tr>
             {{/values.address-street}}
           </tbody>
@@ -86,17 +86,17 @@
             <tr>
               <td>{{#t}}pages.check-details.table.headers.fullname{{/t}}</td>
               <td>{{values.fullname}}</td>
-              <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="personal-details/edit#fullname" class="button">{{#t}}buttons.change.fullname{{/t}}</a></td>
             </tr>
             <tr>
               <td>{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</td>
               <td>{{values.date-of-birth-formatted}}</td>
-              <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="personal-details/edit#date-of-birth-day" class="button">{{#t}}buttons.change.date-of-birth{{/t}}</a></td>
             </tr>
             <tr>
               <td>{{#t}}pages.check-details.table.headers.nationality{{/t}}</td>
               <td>{{values.nationality}}</td>
-              <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
             </tr>
             {{#values.no-email}}
             {{#values.contact-address-street}}
@@ -108,7 +108,7 @@
                   {{#values.contact-address-county}}{{values.contact-address-county}},{{/values.contact-address-county}}
                   {{values.contact-address-postcode}}
                 </td>
-                <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+                <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
               </tr>
             {{/values.contact-address-street}}
             {{/values.no-email}}
@@ -116,21 +116,21 @@
               <tr>
                 <td>{{#t}}pages.check-details.table.headers.passport{{/t}}</td>
                 <td>{{values.passport}}</td>
-                <td><a href="personal-details/edit#passport" class="button">{{#t}}buttons.change{{/t}}</a></td>
+                <td><a href="personal-details/edit#passport" class="button">{{#t}}buttons.change.passport{{/t}}</a></td>
               </tr>
             {{/values.passport}}
             {{#values.email}}
               <tr>
                 <td>{{#t}}pages.check-details.table.headers.email{{/t}}</td>
                 <td>{{values.email}}</td>
-                <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change{{/t}}</a></td>
+                <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change.email{{/t}}</a></td>
               </tr>
             {{/values.email}}
             {{#values.phone}}
               <tr>
                 <td>{{#t}}pages.check-details.table.headers.phone{{/t}}</td>
                 <td>{{values.phone}}</td>
-                <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change{{/t}}</a></td>
+                <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change.phone{{/t}}</a></td>
               </tr>
             {{/values.phone}}
           </tbody>

--- a/apps/someone-else/translations/src/en/buttons.json
+++ b/apps/someone-else/translations/src/en/buttons.json
@@ -1,0 +1,17 @@
+{
+  "change": {
+    "someone-else-reason": "Change <span class=\"visuallyhidden\">nomianted person reason</span>",
+    "someone-else-fullname": "Change <span class=\"visuallyhidden\">nominated person full name</span>",
+    "someone-else-date-of-birth": "Change <span class=\"visuallyhidden\">nominated date of birth</span>",
+    "someone-else-nationality": "Change <span class=\"visuallyhidden\">nominated nationality</span>",
+    "someone-else-id-type": "Change <span class=\"visuallyhidden\">nominated id type</span>",
+    "someone-else-id-number": "Change <span class=\"visuallyhidden\">nominated id number</span>",
+    "fullname": "Change <span class=\"visuallyhidden\">full name</span>",
+    "date-of-birth": "Change <span class=\"visuallyhidden\">date of birth</span>",
+    "nationality": "Change <span class=\"visuallyhidden\">nationality</span>",
+    "address": "Change <span class=\"visuallyhidden\">address</span>",
+    "passport": "Change <span class=\"visuallyhidden\">passport</span>",
+    "email": "Change <span class=\"visuallyhidden\">email</span>",
+    "phone": "Change <span class=\"visuallyhidden\">phone</span>"
+  }
+}

--- a/apps/someone-else/views/confirm.html
+++ b/apps/someone-else/views/confirm.html
@@ -40,13 +40,13 @@
               <tr>
                 <td>{{#t}}pages.someone-else-check-details.tables.reason.title{{/t}}</td>
                 <td>{{#t}}fields.someone-else-reason-radio.options.{{values.someone-else-reason-radio}}.label{{/t}}</td>
-                <td><a href="/someone-else/reason/edit#someone-else-reason-radio" class="button">{{#t}}buttons.change{{/t}}</a></td>
+                <td><a href="/someone-else/reason/edit#someone-else-reason-radio" class="button">{{#t}}buttons.change.someone-else-reason{{/t}}</a></td>
               </tr>
               {{#values.incapable-details}}
               <tr>
                 <td>{{#t}}pages.someone-else-check-details.tables.reason.further-details{{/t}}</td>
                 <td>{{values.incapable-details}}</td>
-                <td><a href="/someone-else/arrange/edit#someone-else-fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+                <td><a href="/someone-else/arrange/edit#someone-else-fullname" class="button">{{#t}}buttons.change.someone-else-fullname{{/t}}</a></td>
               </tr>
               {{/values.incapable-details}}
             {{/values.someone-else-reason-radio}}
@@ -54,35 +54,35 @@
             <tr>
               <td>{{#t}}pages.check-details.table.headers.fullname{{/t}}</td>
               <td>{{values.someone-else-fullname}}</td>
-              <td><a href="/someone-else/arrange/edit#someone-else-fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#someone-else-fullname" class="button">{{#t}}buttons.change.someone-else-fullname{{/t}}</a></td>
             </tr>
             {{/values.someone-else-fullname}}
             {{#values.someone-else-date}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</td>
               <td>{{values.someone-else-date-formatted}}</td>
-              <td><a href="/someone-else/arrange/edit#someone-else-date-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#someone-else-date-day" class="button">{{#t}}buttons.change.someone-else-date-of-birth{{/t}}</a></td>
             </tr>
             {{/values.someone-else-date}}
             {{#values.someone-else-nationality}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.nationality{{/t}}</td>
               <td>{{values.someone-else-nationality}}</td>
-              <td><a href="/someone-else/arrange/edit#someone-else-nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#someone-else-nationality" class="button">{{#t}}buttons.change.someone-else-nationality{{/t}}</a></td>
             </tr>
             {{/values.someone-else-nationality}}
             {{#values.someone-else-id-type}}
             <tr>
               <td>{{#t}}fields.someone-else-id-type.legend{{/t}}</td>
               <td>{{#t}}fields.someone-else-id-type.options.{{values.someone-else-id-type}}.label{{/t}}</td>
-              <td><a href="/someone-else/arrange/edit#someone-else-id-type-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#someone-else-id-type-group" class="button">{{#t}}buttons.change.someone-else-id-type{{/t}}</a></td>
             </tr>
             {{/values.someone-else-id-type}}
             {{#values.someone-else-id-number}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.id-number{{/t}}</td>
               <td>{{values.someone-else-id-number}}</td>
-              <td><a href="/someone-else/arrange/edit#someone-else-id-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#someone-else-id-number" class="button">{{#t}}buttons.change.someone-else-id-number{{/t}}</a></td>
             </tr>
             {{/values.someone-else-id-number}}
           </tbody>
@@ -97,35 +97,35 @@
             <tr>
               <td>{{#t}}pages.check-details.table.headers.fullname{{/t}}</td>
               <td>{{values.change-person-fullname}}</td>
-              <td><a href="/someone-else/arrange/edit#change-person-fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#change-person-fullname" class="button">{{#t}}buttons.change.someone-else-fullname{{/t}}</a></td>
             </tr>
             {{/values.change-person-fullname}}
             {{#values.change-person-date}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</td>
               <td>{{values.change-person-date-formatted}}</td>
-              <td><a href="/someone-else/arrange/edit#change-person-date-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#change-person-date-day" class="button">{{#t}}buttons.change.someone-else-date-of-birth{{/t}}</a></td>
             </tr>
             {{/values.change-person-date}}
             {{#values.change-person-nationality}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.nationality{{/t}}</td>
               <td>{{values.change-person-nationality}}</td>
-              <td><a href="/someone-else/arrange/edit#change-person-nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#change-person-nationality" class="button">{{#t}}buttons.change.someone-else-nationality{{/t}}</a></td>
             </tr>
             {{/values.change-person-nationality}}
             {{#values.change-person-id-type}}
             <tr>
               <td>{{#t}}fields.change-person-id-type.legend{{/t}}</td>
               <td>{{#t}}fields.change-person-id-type.options.{{values.change-person-id-type}}.label{{/t}}</td>
-              <td><a href="/someone-else/arrange/edit#change-person-id-type-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#change-person-id-type-group" class="button">{{#t}}buttons.change.someone-else-id-type{{/t}}</a></td>
             </tr>
             {{/values.change-person-id-type}}
             {{#values.change-person-id-number}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.id-number{{/t}}</td>
               <td>{{values.change-person-id-number}}</td>
-              <td><a href="/someone-else/arrange/edit#change-person-id-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="/someone-else/arrange/edit#change-person-id-number" class="button">{{#t}}buttons.change.someone-else-id-number{{/t}}</a></td>
             </tr>
             {{/values.change-person-id-number}}
           </tbody>
@@ -139,21 +139,21 @@
           <tr>
             <td>{{#t}}pages.check-details.table.headers.fullname{{/t}}</td>
             <td>{{values.fullname}}</td>
-            <td><a href="personal-details{{#values.no-reason}}-no-reason{{/values.no-reason}}/edit#fullname" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details{{#values.no-reason}}-no-reason{{/values.no-reason}}/edit#fullname" class="button">{{#t}}buttons.change.fullname{{/t}}</a></td>
           </tr>
           {{/values.fullname}}
           {{#values.date-of-birth}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</td>
             <td>{{values.date-of-birth-formatted}}</td>
-            <td><a href="personal-details{{#values.no-reason}}-no-reason{{/values.no-reason}}/edit#date-of-birth-day" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details{{#values.no-reason}}-no-reason{{/values.no-reason}}/edit#date-of-birth-day" class="button">{{#t}}buttons.change.date-of-birth{{/t}}</a></td>
           </tr>
           {{/values.date-of-birth}}
           {{#values.nationality}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.nationality{{/t}}</td>
             <td>{{values.nationality}}</td>
-            <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
           </tr>
           {{/values.nationality}}
           {{#values.no-email}}
@@ -166,7 +166,7 @@
                 {{#values.contact-address-county}}{{values.contact-address-county}},{{/values.contact-address-county}}
                 {{values.contact-address-postcode}}
               </td>
-              <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
             </tr>
           {{/values.contact-address-street}}
           {{/values.no-email}}
@@ -174,21 +174,21 @@
           <tr>
             <td>{{#t}}pages.check-details.table.headers.passport{{/t}}</td>
             <td>{{values.passport}}</td>
-            <td><a href="personal-details{{#values.no-reason}}-no-reason{{/values.no-reason}}/edit#passport" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="personal-details{{#values.no-reason}}-no-reason{{/values.no-reason}}/edit#passport" class="button">{{#t}}buttons.change.passport{{/t}}</a></td>
           </tr>
           {{/values.passport}}
           {{#values.email}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.email{{/t}}</td>
             <td>{{values.email}}</td>
-            <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="contact-details/edit#email" class="button">{{#t}}buttons.change.email{{/t}}</a></td>
           </tr>
           {{/values.email}}
           {{#values.phone}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.phone{{/t}}</td>
               <td>{{values.phone}}</td>
-              <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change{{/t}}</a></td>
+              <td><a href="contact-details/edit#phone" class="button">{{#t}}buttons.change.phone{{/t}}</a></td>
             </tr>
           {{/values.phone}}
         </tbody>


### PR DESCRIPTION
When people browse the page in "links mode" they will now be able to see more context rather than just "Change" everywhere