### PR TITLE
Skip to content should actually skip to the main content

### DIFF
--- a/acceptance_tests/features/CollectionFormChangeWithNominee.feature
+++ b/acceptance_tests/features/CollectionFormChangeWithNominee.feature
@@ -11,7 +11,7 @@ Feature: Change details of Nominee
 
     Examples:
       |xpath                             |
-      |/html/body/main/div[2]/div/form/table[2]/tbody/tr[1]/td[3]/a|
-      |/html/body/main/div[2]/div/form/table[2]/tbody/tr[2]/td[3]/a|
-      |/html/body/main/div[2]/div/form/table[2]/tbody/tr[3]/td[3]/a|
-      |/html/body/main/div[2]/div/form/table[2]/tbody/tr[4]/td[3]/a|
+      |/html/body/main/div/div/form/table[2]/tbody/tr[1]/td[3]/a|
+      |/html/body/main/div/div/form/table[2]/tbody/tr[2]/td[3]/a|
+      |/html/body/main/div/div/form/table[2]/tbody/tr[3]/td[3]/a|
+      |/html/body/main/div/div/form/table[2]/tbody/tr[4]/td[3]/a|

--- a/acceptance_tests/features/CollectionFormStep04Validation.feature
+++ b/acceptance_tests/features/CollectionFormStep04Validation.feature
@@ -6,9 +6,9 @@ Feature: Validation for Step 04 of the Collection Form
 
 	Scenario: Selecting "Continue" without filling in the required fields
 		When I click "Continue"
-		Then I see the "Enter your full name" link in the "/html/body/main/div[2]/div/div/ul/li[1]/a" xpath
-		Then I see the "Enter your date of birth" link in the "/html/body/main/div[2]/div/div/ul/li[2]/a" xpath
-		Then I see the "What is your nationality?" link in the "/html/body/main/div[2]/div/div/ul/li[3]/a" xpath
-		Then I see "Enter your full name" in the "/html/body/main/div[2]/div/form/div[1]/label/span[1]" xpath
-		Then I see "Enter your date of birth" in the "/html/body/main/div[2]/div/form/fieldset/span" xpath
-		Then I see "What is your nationality?" in the "/html/body/main/div[2]/div/form/div[2]/label/span[1]" xpath
+		Then I see the "Enter your full name" link in the "/html/body/main/div/div/div/ul/li[1]/a" xpath
+		Then I see the "Enter your date of birth" link in the "/html/body/main/div/div/div/ul/li[2]/a" xpath
+		Then I see the "What is your nationality?" link in the "/html/body/main/div/div/div/ul/li[3]/a" xpath
+		Then I see "Enter your full name" in the "/html/body/main/div/div/form/div[1]/label/span[1]" xpath
+		Then I see "Enter your date of birth" in the "/html/body/main/div/div/form/fieldset/span" xpath
+		Then I see "What is your nationality?" in the "/html/body/main/div/div/form/div[2]/label/span[1]" xpath

--- a/acceptance_tests/features/CollectionFormStep05ChangeDetails.feature
+++ b/acceptance_tests/features/CollectionFormStep05ChangeDetails.feature
@@ -38,9 +38,9 @@ Feature: Changing Delivery Form details
 
 		Examples:
 			|xpath													 	 |
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[1]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[2]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[3]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[1]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[2]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[3]/td[3]/a|
 
 	Scenario Outline: Changing the email value from Step 05 of the collection form
 		When I go to Step Six of the collection form
@@ -53,8 +53,8 @@ Feature: Changing Delivery Form details
 
 		Examples:
 			|xpath													 	 |
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[5]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[6]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[5]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[6]/td[3]/a|
 
 	Scenario: Go to Step Six and clear the cookies
 		When I go to Step Six of the collection form

--- a/acceptance_tests/features/DeliveryFormStep03Validation.feature
+++ b/acceptance_tests/features/DeliveryFormStep03Validation.feature
@@ -6,12 +6,12 @@ Feature: Validation for Step 03 of the Delivery Form
 
 	Scenario: Attempting to proceed to Step 04 of the Delivery Form without entering anything
 		When I click Continue
-		Then I see the "Enter your full name" link in the "/html/body/main/div[2]/div/div/ul/li[1]/a" xpath
-		Then I see the "Enter your date of birth" link in the "/html/body/main/div[2]/div/div/ul/li[2]/a" xpath
-		Then I see the "What is your nationality?" link in the "/html/body/main/div[2]/div/div/ul/li[3]/a" xpath
-		Then I see the "Enter your full name" link in the "/html/body/main/div[2]/div/form/div[1]/label/span[1]" xpath
-		Then I see the "Enter your date of birth" link in the "/html/body/main/div[2]/div/form/fieldset/span" xpath
-		Then I see the "What is your nationality?" link in the "/html/body/main/div[2]/div/form/div[2]/label/span[1]" xpath
+		Then I see the "Enter your full name" link in the "/html/body/main/div/div/div/ul/li[1]/a" xpath
+		Then I see the "Enter your date of birth" link in the "/html/body/main/div/div/div/ul/li[2]/a" xpath
+		Then I see the "What is your nationality?" link in the "/html/body/main/div/div/div/ul/li[3]/a" xpath
+		Then I see the "Enter your full name" link in the "/html/body/main/div/div/form/div[1]/label/span[1]" xpath
+		Then I see the "Enter your date of birth" link in the "/html/body/main/div/div/form/fieldset/span" xpath
+		Then I see the "What is your nationality?" link in the "/html/body/main/div/div/form/div[2]/label/span[1]" xpath
 
 	Scenario: Attempting to proceed to Step 04 of the Delivery Form without entering something in the name field
 		When I enter a valid date of birth

--- a/acceptance_tests/features/DeliveryFormStep05ChangeDetails.feature
+++ b/acceptance_tests/features/DeliveryFormStep05ChangeDetails.feature
@@ -14,10 +14,10 @@ Feature: Changing Delivery Form details
 
 		Examples:
 			|xpath													  |
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[1]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[2]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[3]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[4]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[1]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[2]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[3]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[4]/td[3]/a|
 
 	Scenario Outline: Changing the email value from Step 04 of the delivery form
 		When I go to Step Five of the delivery form
@@ -30,12 +30,12 @@ Feature: Changing Delivery Form details
 
 		Examples:
 			|xpath													  |
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[5]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[6]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[5]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[6]/td[3]/a|
 
 	Scenario: Changing the address values from Step 04 of the delivery form
 		Given I have provided a contact address and I am on Step Five of the delivery form
-		And I click the "Change" link in the "/html/body/main/div[2]/div/form/table/tbody/tr[4]/td[3]/a"
+		And I click the "Change" link in the "/html/body/main/div/div/form/table/tbody/tr[4]/td[3]/a"
 		Then I see the contact address I entered on Step Four of the delivery form
 		When I change the value in the House name field of Step Four of the delivery form
 		And I change the value in the Town/City field of Step Four of the delivery form

--- a/acceptance_tests/features/ErrorFormStep06ChangeDetails.feature
+++ b/acceptance_tests/features/ErrorFormStep06ChangeDetails.feature
@@ -6,7 +6,7 @@ Feature: Changing Error Form details
 		When I check the "<error>" checkbox
 		And fill the "<field>" with the value "<value>"
 		And I go through to Step Six of the error form
-		And I click the "Change" link in the "/html/body/main/div[2]/div/form/table[1]/tbody/tr/td[3]/a"
+		And I click the "Change" link in the "/html/body/main/div/div/form/table[1]/tbody/tr/td[3]/a"
 		When I fill the "<field>" with "<another value>"
 		And I click "Continue"
 		Then I see "<another value>" on Step Six of the error form
@@ -36,10 +36,10 @@ Feature: Changing Error Form details
 
 		Examples:
 			|xpath													  	 |
-			|/html/body/main/div[2]/div/form/table[3]/tbody/tr[1]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[3]/tbody/tr[2]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[3]/tbody/tr[3]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[3]/tbody/tr[4]/td[3]/a|
+			|/html/body/main/div/div/form/table[3]/tbody/tr[1]/td[3]/a|
+			|/html/body/main/div/div/form/table[3]/tbody/tr[2]/td[3]/a|
+			|/html/body/main/div/div/form/table[3]/tbody/tr[3]/td[3]/a|
+			|/html/body/main/div/div/form/table[3]/tbody/tr[4]/td[3]/a|
 
 	Scenario Outline: Changing the email value from Step 04 of the Error form
 		When I go to Step Six of the error form
@@ -52,12 +52,12 @@ Feature: Changing Error Form details
 
 		Examples:
 			|xpath													  	 |
-			|/html/body/main/div[2]/div/form/table[3]/tbody/tr[5]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[3]/tbody/tr[6]/td[3]/a|
+			|/html/body/main/div/div/form/table[3]/tbody/tr[5]/td[3]/a|
+			|/html/body/main/div/div/form/table[3]/tbody/tr[6]/td[3]/a|
 
 	Scenario: Changing the address values from Step 05 of the Error form
 		Given I have provided a contact address and I am on Step Five of the error form
-		And I click the "Change" link in the "/html/body/main/div[2]/div/form/table/tbody/tr[4]/td[3]/a"
+		And I click the "Change" link in the "/html/body/main/div/div/form/table/tbody/tr[4]/td[3]/a"
 		Then I see the contact address I entered on Step Five of the error form
 		When I change the value in the House name field of Step Four of the error form
 		And I change the value in the Town/City field of Step Four of the error form

--- a/acceptance_tests/features/LostStolenDamagedFormStep03Validation.feature
+++ b/acceptance_tests/features/LostStolenDamagedFormStep03Validation.feature
@@ -6,12 +6,12 @@ Feature: Validation for Step 03 of the Lost Stolen Damaged Form
 
 	Scenario: Attempting to proceed to Step 04 of the Lost Stolen Damaged Form without entering anything
 		When I click Continue
-		Then I see the "Enter your full name" link in the "/html/body/main/div[2]/div/div/ul/li[1]/a" xpath
-		Then I see the "Enter your date of birth" link in the "/html/body/main/div[2]/div/div/ul/li[2]/a" xpath
-		Then I see the "What is your nationality?" link in the "/html/body/main/div[2]/div/div/ul/li[3]/a" xpath
-		Then I see the "Enter your full name" link in the "/html/body/main/div[2]/div/form/div[1]/label/span[1]" xpath
-		Then I see the "Enter your date of birth" link in the "/html/body/main/div[2]/div/form/fieldset/span" xpath
-		Then I see the "What is your nationality?" link in the "/html/body/main/div[2]/div/form/div[2]/label/span[1]" xpath
+		Then I see the "Enter your full name" link in the "/html/body/main/div/div/div/ul/li[1]/a" xpath
+		Then I see the "Enter your date of birth" link in the "/html/body/main/div/div/div/ul/li[2]/a" xpath
+		Then I see the "What is your nationality?" link in the "/html/body/main/div/div/div/ul/li[3]/a" xpath
+		Then I see the "Enter your full name" link in the "/html/body/main/div/div/form/div[1]/label/span[1]" xpath
+		Then I see the "Enter your date of birth" link in the "/html/body/main/div/div/form/fieldset/span" xpath
+		Then I see the "What is your nationality?" link in the "/html/body/main/div/div/form/div[2]/label/span[1]" xpath
 
 	Scenario: Attempting to proceed to Step 04 of the Lost Stolen Damaged Form without entering something in the name field
 		When I enter a valid date of birth

--- a/acceptance_tests/features/LostStolenDamagedFormStep05ChangeDetails.feature
+++ b/acceptance_tests/features/LostStolenDamagedFormStep05ChangeDetails.feature
@@ -14,10 +14,10 @@ Feature: Changing Lost Stolen Damaged Form details
 
 		Examples:
 			|xpath													  |
-			|/html/body/main/div[2]/div/form/table/tbody/tr[1]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table/tbody/tr[2]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table/tbody/tr[3]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table/tbody/tr[4]/td[3]/a|
+			|/html/body/main/div/div/form/table/tbody/tr[1]/td[3]/a|
+			|/html/body/main/div/div/form/table/tbody/tr[2]/td[3]/a|
+			|/html/body/main/div/div/form/table/tbody/tr[3]/td[3]/a|
+			|/html/body/main/div/div/form/table/tbody/tr[4]/td[3]/a|
 
 	Scenario Outline: Changing the email value from Step 04 of the Lost Stolen Damaged form
 		When I go to Step Five of the lost stolen damaged form
@@ -30,12 +30,12 @@ Feature: Changing Lost Stolen Damaged Form details
 
 		Examples:
 			|xpath													  |
-			|/html/body/main/div[2]/div/form/table/tbody/tr[5]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table/tbody/tr[6]/td[3]/a|
+			|/html/body/main/div/div/form/table/tbody/tr[5]/td[3]/a|
+			|/html/body/main/div/div/form/table/tbody/tr[6]/td[3]/a|
 
 	Scenario: Changing the address values from Step 04 of the Lost Stolen Damaged form
 		Given I have provided a contact address and I am on Step Five of the lost stolen damaged form
-		And I click the "Change" link in the "/html/body/main/div[2]/div/form/table/tbody/tr[4]/td[3]/a"
+		And I click the "Change" link in the "/html/body/main/div/div/form/table/tbody/tr[4]/td[3]/a"
 		Then I see the contact address I entered on Step Four of the lost stolen damaged form
 		When I change the value in the House name field of Step Four of the lost stolen damaged form
 		And I change the value in the Town/City field of Step Four of the lost stolen damaged form

--- a/acceptance_tests/features/SomeoneElseFormStep01Validation.feature
+++ b/acceptance_tests/features/SomeoneElseFormStep01Validation.feature
@@ -4,13 +4,13 @@ Feature: Validation for Step 01 of the Someone Else Form
 	Scenario: Attempt to proceed to Step 02 but not filling in the fields
 		When I go to Step One of the someone else form
 		And I click "Continue"
-		Then I see the "What is the nominated person's full name?" link in the "/html/body/main/div[2]/div/div/ul/li[1]/a" xpath
-		And I see the "What is the nominated person's date of birth?" link in the "/html/body/main/div[2]/div/div/ul/li[2]/a" xpath
-		And I see the "What is the nominated person's nationality?" link in the "/html/body/main/div[2]/div/div/ul/li[3]/a" xpath
-		And I see the "What is the nominated person's identity document number?" link in the "/html/body/main/div[2]/div/div/ul/li[5]/a" xpath
-		And I see "What is the nominated person's full name?" in the "/html/body/main/div[2]/div/form/div[1]/div[1]/label/span[2]" xpath
-		And I see "What is the nominated person's date of birth?" in the "/html/body/main/div[2]/div/form/div[1]/fieldset/div/span" xpath
-		And I see "What is the nominated person's nationality?" in the "/html/body/main/div[2]/div/form/div[1]/div[2]/label/span[2]" xpath
+		Then I see the "What is the nominated person's full name?" link in the "/html/body/main/div/div/div/ul/li[1]/a" xpath
+		And I see the "What is the nominated person's date of birth?" link in the "/html/body/main/div/div/div/ul/li[2]/a" xpath
+		And I see the "What is the nominated person's nationality?" link in the "/html/body/main/div/div/div/ul/li[3]/a" xpath
+		And I see the "What is the nominated person's identity document number?" link in the "/html/body/main/div/div/div/ul/li[5]/a" xpath
+		And I see "What is the nominated person's full name?" in the "/html/body/main/div/div/form/div[1]/div[1]/label/span[2]" xpath
+		And I see "What is the nominated person's date of birth?" in the "/html/body/main/div/div/form/div[1]/fieldset/div/span" xpath
+		And I see "What is the nominated person's nationality?" in the "/html/body/main/div/div/form/div[1]/div[2]/label/span[2]" xpath
 		And I see "What is the nominated person's identity type?"
 
 	Scenario: Attempt to proceed to Step 02 and nominating a child to collect the BRP

--- a/acceptance_tests/features/SomeoneElseFormStep03Validation.feature
+++ b/acceptance_tests/features/SomeoneElseFormStep03Validation.feature
@@ -6,12 +6,12 @@ Feature: Validation for Step 03 of the Someone Else Form
 
 	Scenario: Attempting to proceed to Step 04 of the Delivery Form without entering anything
 		When I click Continue
-		Then I see the "Enter your full name" link in the "/html/body/main/div[2]/div/div/ul/li[1]/a" xpath
-		Then I see the "Enter your date of birth" link in the "/html/body/main/div[2]/div/div/ul/li[2]/a" xpath
-		Then I see the "What is your nationality?" link in the "/html/body/main/div[2]/div/div/ul/li[3]/a" xpath
-		Then I see the "Enter your full name" link in the "/html/body/main/div[2]/div/form/div[1]/label/span[1]" xpath
-		Then I see the "Enter your date of birth" link in the "/html/body/main/div[2]/div/form/fieldset/span" xpath
-		Then I see the "What is your nationality?" link in the "/html/body/main/div[2]/div/form/div[2]/label/span[1]" xpath
+		Then I see the "Enter your full name" link in the "/html/body/main/div/div/div/ul/li[1]/a" xpath
+		Then I see the "Enter your date of birth" link in the "/html/body/main/div/div/div/ul/li[2]/a" xpath
+		Then I see the "What is your nationality?" link in the "/html/body/main/div/div/div/ul/li[3]/a" xpath
+		Then I see the "Enter your full name" link in the "/html/body/main/div/div/form/div[1]/label/span[1]" xpath
+		Then I see the "Enter your date of birth" link in the "/html/body/main/div/div/form/fieldset/span" xpath
+		Then I see the "What is your nationality?" link in the "/html/body/main/div/div/form/div[2]/label/span[1]" xpath
 
 	Scenario: Attempting to proceed to Step 04 of the Delivery Form without entering something in the name field
 		When I enter a valid date of birth

--- a/acceptance_tests/features/SomeoneElseFormStep05ChangeDetails.feature
+++ b/acceptance_tests/features/SomeoneElseFormStep05ChangeDetails.feature
@@ -11,10 +11,10 @@ Feature: Changing Someone Else Form details
 
 		Examples:
 			|xpath													  	 |
-			|/html/body/main/div[2]/div/form/table[1]/tbody/tr[2]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[1]/tbody/tr[3]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[1]/tbody/tr[4]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[1]/tbody/tr[5]/td[3]/a|
+			|/html/body/main/div/div/form/table[1]/tbody/tr[2]/td[3]/a|
+			|/html/body/main/div/div/form/table[1]/tbody/tr[3]/td[3]/a|
+			|/html/body/main/div/div/form/table[1]/tbody/tr[4]/td[3]/a|
+			|/html/body/main/div/div/form/table[1]/tbody/tr[5]/td[3]/a|
 
 	Scenario Outline: Changing the values from Step 03 of the Someone Else form
 		When I go to Step Five of the someone else form
@@ -26,10 +26,10 @@ Feature: Changing Someone Else Form details
 
 	Examples:
 		|xpath 														 |
-		|/html/body/main/div[2]/div/form/table[2]/tbody/tr[1]/td[3]/a|
-		|/html/body/main/div[2]/div/form/table[2]/tbody/tr[2]/td[3]/a|
-		|/html/body/main/div[2]/div/form/table[2]/tbody/tr[3]/td[3]/a|
-		|/html/body/main/div[2]/div/form/table[2]/tbody/tr[3]/td[3]/a|
+		|/html/body/main/div/div/form/table[2]/tbody/tr[1]/td[3]/a|
+		|/html/body/main/div/div/form/table[2]/tbody/tr[2]/td[3]/a|
+		|/html/body/main/div/div/form/table[2]/tbody/tr[3]/td[3]/a|
+		|/html/body/main/div/div/form/table[2]/tbody/tr[3]/td[3]/a|
 
 	Scenario Outline: Changing the email value from Step 05 of the Someone Else form
 		When I go to Step Five of the someone else form
@@ -42,5 +42,5 @@ Feature: Changing Someone Else Form details
 
 		Examples:
 			|xpath													 	 |
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[5]/td[3]/a|
-			|/html/body/main/div[2]/div/form/table[2]/tbody/tr[6]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[5]/td[3]/a|
+			|/html/body/main/div/div/form/table[2]/tbody/tr[6]/td[3]/a|

--- a/apps/common/views/layout.html
+++ b/apps/common/views/layout.html
@@ -12,13 +12,15 @@
 {{$insideHeader}}{{/insideHeader}}
 
 {{$main}}
-  <main id="content" class="main" role="main">
+  <header id="banner-content">
     <div class="phase-banner">
       <p>
         <strong class="phase-tag">BETA</strong>
         <span>This is a new service – your <a href="mailto:brpformfeedback@homeoffice.gsi.gov.uk?subject=BRP Beta feedback">feedback</a> will help us to improve it.</span>
       </p>
     </div>
+  </header>
+  <main id="content" class="main" role="main">
     <span id="step">
       {{> partials-back}} <span>{{$step}}{{/step}}</span>
     </span>

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -5,6 +5,12 @@
 @import "./validation.scss";
 
 
+#banner-content {
+  @extend #content;
+  padding-bottom: 0;
+}
+
+
 .phase-banner {
   @include phase-banner(beta);
 }


### PR DESCRIPTION
At the moment it skips to the phase banner which means it reads (alpha, beta) ever time the user has opted to skip to the main content.

As this is not main content we're going to skip to the step number onwards from now on.