### PR TITLE
Add so-acceptance happy path tests for '/collection'

### DIFF
--- a/acceptance_tests/features/step_definitions/A_Common_Reusable_Steps.rb
+++ b/acceptance_tests/features/step_definitions/A_Common_Reusable_Steps.rb
@@ -209,7 +209,7 @@ end
 # => DSP-67_.steps
 #
 When(/^I check the I want to be contacted by post checkbox$/) do
-  check('no-email')
+  check('use-address')
 end
 
 When(/^I enter an email address without an @$/) do

--- a/acceptance_tests/features/step_definitions/ChangingDeliveryFormDetails_.rb
+++ b/acceptance_tests/features/step_definitions/ChangingDeliveryFormDetails_.rb
@@ -74,7 +74,7 @@ Given(/^I have provided a contact address and I am on Step Five of the delivery 
   fill_in('nationality', :with => 'China')
   fill_in('passport', :with => '123456789')
   click_button('Continue')
-  check('no-email')
+  check('use-address')
   fill_in('contact-address-house-number', :with => '2')
   fill_in('contact-address-street', :with => 'Marsham Street')
   fill_in('contact-address-town', :with => 'Westminster')

--- a/acceptance_tests/features/step_definitions/ChangingErrorFormDetails_.rb
+++ b/acceptance_tests/features/step_definitions/ChangingErrorFormDetails_.rb
@@ -77,7 +77,7 @@ Given(/^I have provided a contact address and I am on Step Five of the error for
   fill_in('brp-card', :with => '1234567890')
   # page.status_code.should == 302
   click_button('Continue')
-  check('no-email')
+  check('use-address')
   complete_address_fields_with_prefix "contact-"
   click_button('Continue')
   # page.status_code.should == 302

--- a/acceptance_tests/features/step_definitions/ChangingLostStolenDamagedFormDetails_.rb
+++ b/acceptance_tests/features/step_definitions/ChangingLostStolenDamagedFormDetails_.rb
@@ -28,7 +28,7 @@ Then(/^I can see the changed email address and phone number from step four of th
   delete_cookie('hmbrp.sid')
 end
 
-Given(/^I have provided a contact address and I am on Step Five of the lost stolen damaged form$/) do                                           
+Given(/^I have provided a contact address and I am on Step Five of the lost stolen damaged form$/) do
   visit config['lost_stolen_host']
   choose('UK')
   click_button('Continue')
@@ -43,7 +43,7 @@ Given(/^I have provided a contact address and I am on Step Five of the lost stol
   fill_in('nationality', :with => 'China')
   fill_in('brp-card', :with => '123456789')
   click_button('Continue')
-  check('no-email')
+  check('use-address')
   complete_address_fields_with_prefix "contact-"
   click_button('Continue')
 end

--- a/acceptance_tests/features/step_definitions/CollectionFormStep05_.rb
+++ b/acceptance_tests/features/step_definitions/CollectionFormStep05_.rb
@@ -25,7 +25,7 @@ Then(/^I am on Step Five of the collection form$/) do
   page.should have_content('How should we contact you about your BRP?')
   page.should have_content('Email address')
   find_by_id('email')
-  find_by_id('no-email')
+  find_by_id('use-address')
   page.should have_content('I want to be contacted by post')
   page.should have_content('Phone number (optional)')
   find_field('phone')

--- a/acceptance_tests/features/step_definitions/DeliveryFormStep04.rb
+++ b/acceptance_tests/features/step_definitions/DeliveryFormStep04.rb
@@ -26,7 +26,7 @@ Then(/^I am on Step Four of the delivery form$/) do
   page.should have_content('How should we contact you about your BRP?')
   page.should have_content('Email address')
   find_by_id('email')
-  find_by_id('no-email')
+  find_by_id('use-address')
   page.should have_content('I want to be contacted by post')
   # page.should have_content('Provide your address so that we contact you by post')
   # page.should have_content('House name or number and street')

--- a/acceptance_tests/features/step_definitions/SomeoneElseFormStep04_.rb
+++ b/acceptance_tests/features/step_definitions/SomeoneElseFormStep04_.rb
@@ -24,7 +24,7 @@ Then(/^I am on Step Four of the somone else form$/) do
   page.should have_content('How should we contact you about your BRP?')
   page.should have_content('Email address')
   find_by_id('email')
-  find_by_id('no-email')
+  find_by_id('use-address')
   page.should have_content('I want to be contacted by post')
   find_by_id('phone')
   find_button('Continue').click

--- a/apps/collection/acceptance/features/_happy-path.js
+++ b/apps/collection/acceptance/features/_happy-path.js
@@ -1,0 +1,16 @@
+'use strict';
+
+Feature('Collection - Happy path');
+
+Before((
+  I
+) => {
+  I.amOnPage('/collection/where');
+});
+
+Scenario('An applicaton can be completed end-to-end', (
+  I
+) => {
+  I.completeToStep('/collection/confirmation', {'org-help': 'yes'});
+});
+

--- a/apps/collection/steps.js
+++ b/apps/collection/steps.js
@@ -69,7 +69,7 @@ module.exports = {
   '/contact-details': {
     fields: [
       'email',
-      'no-email',
+      'use-address',
       'contact-address-house-number',
       'contact-address-street',
       'contact-address-town',

--- a/apps/collection/translations/src/en/fields.json
+++ b/apps/collection/translations/src/en/fields.json
@@ -129,7 +129,7 @@
     "email": {
       "label": "Email address"
     },
-    "no-email": {
+    "use-address": {
       "label": "I want to be contacted by post"
     },
     "phone": {

--- a/apps/collection/views/confirm.html
+++ b/apps/collection/views/confirm.html
@@ -175,7 +175,7 @@
             <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
           </tr>
           {{/values.nationality}}
-          {{#values.no-email}}
+          {{#values.use-address}}
           {{#values.contact-address-street}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.contact-address{{/t}}</td>
@@ -188,7 +188,7 @@
               <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
             </tr>
           {{/values.contact-address-street}}
-          {{/values.no-email}}
+          {{/values.use-address}}
           {{#values.passport}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.passport{{/t}}</td>

--- a/apps/collection/views/contact-details.html
+++ b/apps/collection/views/contact-details.html
@@ -33,7 +33,7 @@
 
       {{#input-text}}email{{/input-text}}
 
-      {{#checkbox}}no-email{{/checkbox}}
+      {{#checkbox}}use-address{{/checkbox}}
 
       <fieldset id="address-group" class="panel-indent js-hidden">
         <legend class="visuallyhidden">

--- a/apps/common/fields/contact-details.js
+++ b/apps/common/fields/contact-details.js
@@ -6,10 +6,10 @@ module.exports = {
     type: 'email',
     dependent: {
       value: '',
-      field: 'no-email'
+      field: 'use-address'
     }
   },
-  'no-email': {
+  'use-address': {
     toggle: 'address-group'
   },
   'contact-address-house-number': {
@@ -17,7 +17,7 @@ module.exports = {
       label: 'common-fields.address-house-number.label',
       dependent: {
         value: 'true',
-        field: 'no-email'
+        field: 'use-address'
       }
   },
   'contact-address-street': {
@@ -25,7 +25,7 @@ module.exports = {
     label: 'common-fields.address-street.label',
     dependent: {
       value: 'true',
-      field: 'no-email'
+      field: 'use-address'
     }
   },
   'contact-address-town': {
@@ -33,7 +33,7 @@ module.exports = {
     label: 'common-fields.address-town.label',
     dependent: {
       value: 'true',
-      field: 'no-email'
+      field: 'use-address'
     }
   },
   'contact-address-county': {
@@ -44,7 +44,7 @@ module.exports = {
     label: 'common-fields.address-postcode.label',
     dependent: {
       value: 'true',
-      field: 'no-email'
+      field: 'use-address'
     }
   }
 };

--- a/apps/correct-mistakes/steps.js
+++ b/apps/correct-mistakes/steps.js
@@ -124,7 +124,7 @@ module.exports = {
   '/contact-details': {
     fields: [
       'email',
-      'no-email',
+      'use-address',
       'contact-address-house-number',
       'contact-address-street',
       'contact-address-town',

--- a/apps/correct-mistakes/translations/src/en/fields.json
+++ b/apps/correct-mistakes/translations/src/en/fields.json
@@ -49,7 +49,7 @@
   "email": {
     "label": "Email address"
   },
-  "no-email": {
+  "use-address": {
     "label": "I want to be contacted by post"
   },
   "phone": {

--- a/apps/correct-mistakes/views/contact-details.html
+++ b/apps/correct-mistakes/views/contact-details.html
@@ -33,7 +33,7 @@
 
       {{#input-text}}email{{/input-text}}
 
-      {{#checkbox}}no-email{{/checkbox}}
+      {{#checkbox}}use-address{{/checkbox}}
 
       <fieldset id="address-group" class="panel-indent js-hidden">
         <legend class="visuallyhidden">

--- a/apps/lost-stolen/steps.js
+++ b/apps/lost-stolen/steps.js
@@ -41,7 +41,7 @@ module.exports = {
     controller: require('./controllers/contact-details'),
     fields: [
       'email',
-      'no-email',
+      'use-address',
       'contact-address-house-number',
       'contact-address-street',
       'contact-address-town',

--- a/apps/lost-stolen/translations/src/en/fields.json
+++ b/apps/lost-stolen/translations/src/en/fields.json
@@ -30,7 +30,7 @@
   "email": {
     "label": "Email address"
   },
-  "no-email": {
+  "use-address": {
     "label": "I want to be contacted by post"
   },
   "phone": {

--- a/apps/lost-stolen/views/confirm.html
+++ b/apps/lost-stolen/views/confirm.html
@@ -48,7 +48,7 @@
             <td>{{values.nationality}}</td>
             <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
           </tr>
-          {{#values.no-email}}
+          {{#values.use-address}}
           {{#values.contact-address-street}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.contact-address{{/t}}</td>
@@ -61,7 +61,7 @@
               <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
             </tr>
           {{/values.contact-address-street}}
-          {{/values.no-email}}
+          {{/values.use-address}}
           {{#values.brp-card}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.brp-card-number{{/t}}</td>

--- a/apps/lost-stolen/views/contact-details.html
+++ b/apps/lost-stolen/views/contact-details.html
@@ -34,7 +34,7 @@
         {{#input-text}}email{{/input-text}}
 
         {{#insideUk}}
-          {{#checkbox}}no-email{{/checkbox}}
+          {{#checkbox}}use-address{{/checkbox}}
 
           <fieldset id="address-group" class="panel-indent js-hidden">
             <legend class="visuallyhidden">

--- a/apps/not-arrived/steps.js
+++ b/apps/not-arrived/steps.js
@@ -69,7 +69,7 @@ module.exports = {
   '/contact-details': {
     fields: [
       'email',
-      'no-email',
+      'use-address',
       'contact-address-house-number',
       'contact-address-street',
       'contact-address-town',

--- a/apps/not-arrived/translations/src/en/fields.json
+++ b/apps/not-arrived/translations/src/en/fields.json
@@ -69,7 +69,7 @@
   "email": {
     "label": "Email address"
   },
-  "no-email": {
+  "use-address": {
     "label": "I want to be contacted by post"
   },
   "phone": {

--- a/apps/not-arrived/views/confirm.html
+++ b/apps/not-arrived/views/confirm.html
@@ -98,7 +98,7 @@
               <td>{{values.nationality}}</td>
               <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
             </tr>
-            {{#values.no-email}}
+            {{#values.use-address}}
             {{#values.contact-address-street}}
               <tr>
                 <td>{{#t}}pages.check-details.table.headers.contact-address{{/t}}</td>
@@ -111,7 +111,7 @@
                 <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
               </tr>
             {{/values.contact-address-street}}
-            {{/values.no-email}}
+            {{/values.use-address}}
             {{#values.passport}}
               <tr>
                 <td>{{#t}}pages.check-details.table.headers.passport{{/t}}</td>

--- a/apps/not-arrived/views/contact-details.html
+++ b/apps/not-arrived/views/contact-details.html
@@ -33,7 +33,7 @@
 
         {{#input-text}}email{{/input-text}}
 
-        {{#checkbox}}no-email{{/checkbox}}
+        {{#checkbox}}use-address{{/checkbox}}
 
         <fieldset id="address-group" class="panel-indent js-hidden">
           <legend class="visuallyhidden">

--- a/apps/someone-else/steps.js
+++ b/apps/someone-else/steps.js
@@ -62,7 +62,7 @@ module.exports = {
   '/contact-details': {
     fields: [
       'email',
-      'no-email',
+      'use-address',
       'contact-address-house-number',
       'contact-address-street',
       'contact-address-town',

--- a/apps/someone-else/translations/src/en/fields.json
+++ b/apps/someone-else/translations/src/en/fields.json
@@ -80,7 +80,7 @@
   "email": {
     "label": "Email address"
   },
-  "no-email": {
+  "use-address": {
     "label": "I want to be contacted by post"
   },
   "phone": {

--- a/apps/someone-else/views/confirm.html
+++ b/apps/someone-else/views/confirm.html
@@ -111,7 +111,7 @@
             <td><a href="personal-details/edit#nationality" class="button">{{#t}}buttons.change.nationality{{/t}}</a></td>
           </tr>
           {{/values.nationality}}
-          {{#values.no-email}}
+          {{#values.use-address}}
           {{#values.contact-address-street}}
             <tr>
               <td>{{#t}}pages.check-details.table.headers.contact-address{{/t}}</td>
@@ -124,7 +124,7 @@
               <td><a href="contact-details/edit#address-group" class="button">{{#t}}buttons.change.address{{/t}}</a></td>
             </tr>
           {{/values.contact-address-street}}
-          {{/values.no-email}}
+          {{/values.use-address}}
           {{#values.passport}}
           <tr>
             <td>{{#t}}pages.check-details.table.headers.passport{{/t}}</td>

--- a/apps/someone-else/views/contact-details.html
+++ b/apps/someone-else/views/contact-details.html
@@ -33,7 +33,7 @@
 
       {{#input-text}}email{{/input-text}}
 
-      {{#checkbox}}no-email{{/checkbox}}
+      {{#checkbox}}use-address{{/checkbox}}
 
       <fieldset id="address-group" class="panel-indent js-hidden">
         <legend class="visuallyhidden">

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "start": "node .",
     "dev": "NODE_ENV=development hof-build watch",
     "test": "NODE_ENV=test mocha",
-    "test:acceptance": "cd acceptance_tests/; bundle install && cucumber",
+    "test:acceptance": "funkie so-acceptance --steps",
+    "test:acceptance:old": "cd acceptance_tests/; bundle install && cucumber",
     "test:ci": "npm run lint && npm run style && npm run test",
     "lint": "eslint .",
-    "quality": "plato -r -x 'node_modules|reports|test' -d reports/plato .",
     "build": "hof-build",
     "postinstall": "bash -c 'if [[ ${NODE_ENV} != production ]]; then npm run build; fi;'"
   },
@@ -49,6 +49,8 @@
     "eslint-plugin-filenames": "^0.1.1",
     "eslint-plugin-mocha": "^0.2.2",
     "eslint-plugin-one-variable-per-var": "0.0.3",
+    "funkie": "0.0.5",
+    "funkie-phantom": "0.0.1",
     "jscs": "^1.13.1",
     "mocha": "^2.2.5",
     "mocha-junit-reporter": "^1.4.0",
@@ -59,7 +61,8 @@
     "proxyquire": "^1.5.0",
     "sinomocha": "^0.2.4",
     "sinon": "^1.15.3",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "so-acceptance": "^4.3.1"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
This PR adds "happy path" so-acceptance/codecept acceptance tests for the `/collection` app and does not remove the old cucumber acceptance tests.

Also, due to the way that autofil identifies email input fields https://github.com/UKHomeOfficeForms/hof-util-autofill/blob/master/lib/inputs.js#L36 it was necessary change the field `no-email` to `use-address`. therefore this pr also contains many instances of changing that field name.