### PR TITLE
Add so-acceptance tests for the '/correct-mistakes' app

### DIFF
--- a/apps/correct-mistakes/acceptance/features/_happy-path.js
+++ b/apps/correct-mistakes/acceptance/features/_happy-path.js
@@ -1,0 +1,35 @@
+'use strict';
+
+Feature('Correct Mistakes - Happy path');
+
+const values = {
+  'first-name-error-checkbox': 'false',
+  'last-name-error-checkbox': 'false',
+  'date-of-birth-error-checkbox': 'false',
+  'birth-place-error-checkbox': 'false',
+  'gender-error-checkbox': 'true',
+  'gender-error': 'unspecified',
+  'sponsor-details-error-checkbox': 'false',
+  'nationality-error-checkbox': 'false',
+  'signature-error-checkbox': 'false',
+  'photograph-error-checkbox': 'false',
+  'national-insurance-error-checkbox': 'false',
+  'damaged-error-checkbox': 'false',
+  'conditions-error-checkbox': 'false',
+  'letter-error-checkbox': 'false',
+  'use-address': 'true',
+  'org-help': 'yes'
+};
+
+Before((
+  I
+) => {
+  I.amOnPage('/correct-mistakes/location');
+});
+
+Scenario('An applicaton can be completed end-to-end', (
+  I
+) => {
+  I.completeToStep('/correct-mistakes/confirmation', values);
+});
+

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-filenames": "^0.1.1",
     "eslint-plugin-mocha": "^0.2.2",
     "eslint-plugin-one-variable-per-var": "0.0.3",
-    "funkie": "0.0.5",
+    "funkie": "0.0.6",
     "funkie-phantom": "0.0.1",
     "jscs": "^1.13.1",
     "mocha": "^2.2.5",


### PR DESCRIPTION
- include more deps for so-acceptance
- rename a field s/no-email/use-address to avoid autofill conflicts